### PR TITLE
16 fix document viewing

### DIFF
--- a/coderedcms/models/snippet_models.py
+++ b/coderedcms/models/snippet_models.py
@@ -280,48 +280,6 @@ class ContentWall(models.Model):
         return self.name
 
 
-@register_snippet
-class ContentWall(models.Model):
-    """
-    Snippet that restricts access to a page with a modal.
-    """
-    class Meta:
-        verbose_name = _('Content Wall')
-
-    name = models.CharField(
-        max_length=255,
-        verbose_name=_('Name'),
-    )
-    content = StreamField(
-        LAYOUT_STREAMBLOCKS,
-        verbose_name=_('Content'),
-    )
-    is_dismissible = models.BooleanField(
-        default=True,
-        verbose_name=_('Dismissible'),
-    )
-    show_once = models.BooleanField(
-        default=True,
-        verbose_name=_('Show once'),
-        help_text=_('Do not show the content wall to the same user again after it has been closed.')
-    )
-
-    panels = [
-        MultiFieldPanel(
-            [
-                FieldPanel('name'),
-                FieldPanel('is_dismissible'),
-                FieldPanel('show_once'),
-            ],
-            heading=_('Content Wall')
-        ),
-        StreamFieldPanel('content'),
-    ]
-
-    def __str__(self):
-        return self.name
-
-
 class CoderedEmail(ClusterableModel):
     """
     General purpose abstract clusterable model used for holding email information.

--- a/coderedcms/wagtail_hooks.py
+++ b/coderedcms/wagtail_hooks.py
@@ -5,8 +5,6 @@ from django.utils.html import format_html
 from wagtail.contrib.forms.models import AbstractForm
 from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy, get_page_models
-from wagtail.utils import sendfile_streaming_backend
-from wagtail.utils.sendfile import sendfile
 
 from coderedcms import utils
 from coderedcms.models import CoderedFormPage

--- a/coderedcms/wagtail_hooks.py
+++ b/coderedcms/wagtail_hooks.py
@@ -63,3 +63,4 @@ def serve_document_directly(document, request):
     response['Content-Disposition'] = 'inline;filename="{0}"'.format(document.filename)
     response['Content-Encoding'] = content_encoding
     return response
+    


### PR DESCRIPTION
Fixes #16 

Also removes a duplicate definition for `ContentWall`.  Not sure how the model definition was duplicated, probably some merge error.