### PR TITLE
Adding apple-touch-icon

### DIFF
--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -83,8 +83,17 @@
 
         {% block favicon %}
             {% if settings.coderedcms.LayoutSettings.favicon %}
-                {% image settings.coderedcms.LayoutSettings.favicon fill-128x128 format-png as favicon %}
-                <link rel="icon" type="image/png" href="{{favicon.url}}" />
+                {# See https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/app-icon/ #}
+                {% image settings.coderedcms.LayoutSettings.favicon fill-120x120 format-png as favicon_iphone %}
+                {% image settings.coderedcms.LayoutSettings.favicon fill-180x180 format-png as favicon_iphone_plus %}
+                {% image settings.coderedcms.LayoutSettings.favicon fill-152x152 format-png as favicon_ipad %}
+                {% image settings.coderedcms.LayoutSettings.favicon fill-167x167 format-png as favicon_ipad_pro %}
+                <link rel="icon" type="image/png" href="{{ favicon_iphone_plus.url }}" />
+                <link rel="apple-touch-icon" href="{{ favicon_iphone_plus.url }}">
+                <link rel="apple-touch-icon" sizes="120x120" href="{{ favicon_iphone.url }}">
+                <link rel="apple-touch-icon" sizes="180x180" href="{{ favicon_iphone_plus.url }}">
+                <link rel="apple-touch-icon" sizes="152x152" href="{{ favicon_ipad.url }}">
+                <link rel="apple-touch-icon" sizes="167x167" href="{{ favicon_ipad_pro.url }}">
             {% endif %}
         {% endblock %}
 


### PR DESCRIPTION
Following current apple-touch-icon standards here: https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/app-icon/

Using largest one (180x180) for standard favicon.

Adding a magic /favicon.ico to the root url would be nice as many browsers and crawlers expect it to be there from legacy times, but wagtail currently does not have support for generating ico file types.

Pillow can handle this no problem, but ideally we would want to save/cache that as a rendition. Wagtail uses Pillow but wraps it in a library called Willow, so we would have to contribute to Willow to be able to use the `ico` format with renditions.

For how the favicon.ico is not that big of a deal, it would be a nice to have, but would require a bit more work. Apple-touch-icons are much more relevant and an easy add.