### PR TITLE
Better inheritance on form page template

### DIFF
--- a/coderedcms/templates/coderedcms/pages/form_page.html
+++ b/coderedcms/templates/coderedcms/pages/form_page.html
@@ -2,9 +2,9 @@
 
 {% load wagtailcore_tags coderedcms_tags bootstrap4 %}
 
-{% block content %}
+{% block content_body %}
 
-{% include_block page.body with settings=settings %}
+{{ block.super }}
 
 {% if page.form_live %}
 <div class="container">


### PR DESCRIPTION
Form page currently over-writes title and other content blocks form `web_page.html` template. One side effect is the title and cover image do not show. After this fix the form will properly get appended to the content body.