### PR TITLE
Fix cache issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'icalendar==4.0.*',
         'wagtail==2.4.*',
         'wagtailfontawesome>=1.1.3,<2.0',
-        'wagtail-cache==0.3.*',
+        'wagtail-cache==0.4.*',
         'wagtail-import-export>=0.1,<0.2'
     ],
     extras_require={
@@ -55,6 +55,7 @@ setup(
             'pylint-django',
             'sphinx',
             'twine',
+            'wheel'
         ]
     },
     entry_points="""


### PR DESCRIPTION
Fixes #97 . Updating to wagtail-cache 0.4 to fix caching issues.

Never cache form pages due to various complexities (CSRF token, potential view restrictions, changing template/content based on form validation or thank you page, etc).

Also added missing `wheel` package from dev extras.