### PR TITLE
Order default search model (CoderedPage) by last published date new->old

### DIFF
--- a/coderedcms/views.py
+++ b/coderedcms/views.py
@@ -78,7 +78,7 @@ def search(request):
                 except:
                     results = None
             else:
-                results = CoderedPage.objects.live().search(search_query)
+                results = CoderedPage.objects.live().order_by('-last_published_at').search(search_query)
 
         # paginate results
         if results:


### PR DESCRIPTION
Ordering is done on queryset before doing the search. The search backend is still free to reorder the results, however I don't believe the database search backend does any ordering.

When searching on a specific model, do not order, the assumption is the models' Meta ordering will be used.