### PR TITLE
Form landing content

### DIFF
--- a/coderedcms/templates/coderedcms/pages/form_page_landing.html
+++ b/coderedcms/templates/coderedcms/pages/form_page_landing.html
@@ -6,7 +6,7 @@
 
 <div class="container mt-5">
     <h1>{% trans 'Thank You' %}</h1>
-    <p>{% trans 'We have successfully recieved your submission.' %}</p>
+    <p>{% trans 'We have successfully received your submission.' %}</p>
 </div>
 
 {% endblock %}

--- a/coderedcms/templates/coderedcms/pages/form_page_landing.html
+++ b/coderedcms/templates/coderedcms/pages/form_page_landing.html
@@ -1,10 +1,10 @@
 {% extends "coderedcms/pages/web_page.html" %}
 
-{% load i18n wagtailcore_tags coderedcms_tags bootstrap4 %}
+{% load i18n %}
 
 {% block content_body %}
 
-<div class="container mt-5">
+<div class="container my-5">
     <h1>{% trans 'Thank You' %}</h1>
     <p>{% trans 'We have successfully received your submission.' %}</p>
 </div>

--- a/coderedcms/templates/coderedcms/pages/form_page_landing.html
+++ b/coderedcms/templates/coderedcms/pages/form_page_landing.html
@@ -5,7 +5,7 @@
 {% block content_body %}
 
 <div class="container my-5">
-    <h1>{% trans 'Thank You' %}</h1>
+    <h2>{% trans 'Thank You' %}</h2>
     <p>{% trans 'We have successfully received your submission.' %}</p>
 </div>
 

--- a/coderedcms/templates/coderedcms/pages/form_page_landing.html
+++ b/coderedcms/templates/coderedcms/pages/form_page_landing.html
@@ -2,11 +2,11 @@
 
 {% load i18n wagtailcore_tags coderedcms_tags bootstrap4 %}
 
-{% block content %}
+{% block content_body %}
 
 <div class="container mt-5">
     <h1>{% trans 'Thank You' %}</h1>
-    <p>{% trans 'We have successfully recieved your submission for:' %} {{self.title}}.</p>
+    <p>{% trans 'We have successfully recieved your submission.' %}</p>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Moved from block `content` to `content_body` to better match normal form page. Fixed misspelling and also removed unused template tags