### PR TITLE
122 Fix Event Previews

### DIFF
--- a/coderedcms/blocks/content_blocks.py
+++ b/coderedcms/blocks/content_blocks.py
@@ -4,6 +4,7 @@ contain sub-blocks, and may require javascript to function properly.
 """
 
 from django.utils.translation import ugettext_lazy as _
+from taggit.forms import TagField, TagWidget
 from wagtail.core import blocks
 from wagtail.core.models import Page
 from wagtail.documents.blocks import DocumentChooserBlock
@@ -203,6 +204,13 @@ class NavDocumentLinkWithSubLinkBlock(NavSubLinkBlock, NavDocumentLinkBlock):
         label = _('Document link with sub-links')
 
 
+class TagBlock(blocks.CharBlock):
+    widget = TagWidget
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.field = TagField()
+
 class PageListBlock(BaseBlock):
     """
     Renders a preview of selected pages.
@@ -221,6 +229,10 @@ class PageListBlock(BaseBlock):
         label=_('Limit to'),
         help_text=_('Only show pages that are children of the selected page. Uses the subpage sorting as specified in the page’s LAYOUT tab.'),
     )
+    limit_tags = TagBlock(
+        required=False,
+        label=_('Limit Tags'),
+        help_text=_('Only show pages that use these tags.'))
 
     class Meta:
         template = 'coderedcms/blocks/pagelist_block.html'

--- a/coderedcms/templates/coderedcms/includes/struct_data_event.json
+++ b/coderedcms/templates/coderedcms/includes/struct_data_event.json
@@ -47,10 +47,12 @@
 
   "name": "{{self.title}}",
 
-  {% with self.most_recent_occurrence as nextup %}
+  {% with self.next_or_most_recent_ocurrence as nextup %}
+  {% if nextup %}
   "startDate": "{{nextup.0|structured_data_datetime}}",
-  {% if nextup.1 %}
+    {% if nextup.1 %}
   "endDate": "{{nextup.1|structured_data_datetime}}",
+    {% endif %}
   {% endif %}
   {% endwith %}
 

--- a/coderedcms/templates/coderedcms/pages/event_index_page.html
+++ b/coderedcms/templates/coderedcms/pages/event_index_page.html
@@ -36,7 +36,7 @@
                 {% block event_body_preview %}
                     <div class="col-md">
                         <h3><a href="{{ event.url }}">{{ event.title }}</a></h3>
-                        <p>{{ event.most_recent_occurrence.0 }}</p>
+                        <p>{{ event.next_or_most_recent_occurrence.0 }}</p>
                         <p>{{ event.body_preview }}</p>
                     </div>
                 {% endblock %}

--- a/coderedcms/templates/coderedcms/pages/event_page.html
+++ b/coderedcms/templates/coderedcms/pages/event_page.html
@@ -7,7 +7,7 @@
 
 {% block content_pre_body %}
     {{ block.super }}
-    {% with self.most_recent_occurrence as nextup %}
+    {% with self.next_or_most_recent_occurrence as nextup %}
     <div class="container my-5">
         <p class="d-md-inline-block mr-4"><b>When:</b> {{nextup.0}}</p>
         {% if self.address %}


### PR DESCRIPTION
Fixes #122 

I'm not entirely sure of the nature behind this issue.  Wagtail uses a `FakeQuerySet` in previews for some reason.  This `FakeQuerySet` appears to break with some eventtools apis as the `FakeQuerySet` isn't an exact copy of the model's `QuerySet`.  This is only an issue when we call `next_or_most_recent_occurrence` from template tags on previewed pages.  Without going down a miles deep rabbit hole, the solution is to manually calculate the next occurrence when the normal functionality breaks.  That solution is implemented in this PR.

There is another issue with the Event Landing page breaking on preview.  However, that is even harder to debug and unrelated to this specific issue.