### PR TITLE
Updating to wagtailcache 0.5

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1256,8 +1256,6 @@ class CoderedFormPage(CoderedWebPage):
             self.get_landing_page_template(request),
             context
         )
-        # Never cache form landing response, due to content changing with same URL.
-        response['Cache-Control'] = 'no-cache'
         return response
 
     def serve_submissions_list_view(self, request, *args, **kwargs):
@@ -1287,8 +1285,6 @@ class CoderedFormPage(CoderedWebPage):
             self.get_template(request),
             context
         )
-        # Never cache form pages, due to content changing with same URL, and CSRF token.
-        response['Cache-Control'] = 'no-cache'
         return response
 
     preview_modes = [

--- a/coderedcms/project_template/project_name/settings/base.py
+++ b/coderedcms/project_template/project_name/settings/base.py
@@ -63,6 +63,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # Save pages to cache. Must be FIRST.
+    'wagtailcache.cache.UpdateCacheMiddleware',
+
     # Common functionality
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
@@ -80,6 +83,9 @@ MIDDLEWARE = [
     # CMS functionality
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+
+    # Fetch from cache. Must be LAST.
+    'wagtailcache.cache.FetchFromCacheMiddleware',
 ]
 
 ROOT_URLCONF = '{{ project_name }}.urls'

--- a/coderedcms/urls.py
+++ b/coderedcms/urls.py
@@ -1,8 +1,6 @@
-from django.urls import path, re_path
-from django.contrib.auth.views import LoginView
+from django.urls import include, path, re_path
 from wagtail.contrib.sitemaps.views import sitemap
-from wagtail.core.urls import serve_pattern, WAGTAIL_FRONTEND_LOGIN_TEMPLATE
-from wagtail.core import views as wagtail_views
+from wagtail.core import urls as wagtailcore_urls
 from wagtailcache.cache import cache_page
 
 from coderedcms.settings import cr_settings
@@ -11,7 +9,7 @@ from coderedcms.views import (
     event_generate_recurring_ical_for_event,
     event_generate_single_ical_for_event,
     event_get_calendar_events,
-    robots, 
+    robots,
     serve_protected_file
 )
 
@@ -22,23 +20,13 @@ urlpatterns = [
     re_path(r'^robots\.txt$', cache_page(robots), name='codered_robots'),
     re_path(r'^{0}(?P<path>.*)$'.format(cr_settings['PROTECTED_MEDIA_URL'].lstrip('/')), serve_protected_file, name="serve_protected_file"),
 
-    # Direct copy of wagtail.core.urls
-    re_path(
-        r'^_util/authenticate_with_password/(\d+)/(\d+)/$',
-        wagtail_views.authenticate_with_password,
-        name='wagtailcore_authenticate_with_password'
-    ),
-    path('_util/login/', LoginView.as_view(template_name=WAGTAIL_FRONTEND_LOGIN_TEMPLATE), name='wagtailcore_login'),
-
-    #ICAL URLS
+    # Event/Calendar URLs
     path('ical/generate/single/', event_generate_single_ical_for_event, name='event_generate_single_ical'),
     path('ical/generate/recurring/', event_generate_recurring_ical_for_event, name='event_generate_recurring_ical'),
     path('ical/generate/calendar/', event_generate_ical_for_calendar, name='event_generate_ical_for_calendar'),
-
-    #Calendar URLS
     path('ajax/calendar/events/', event_get_calendar_events, name='event_get_calendar_events'),
 
-    # Wrap the serve function with coderedcms cache
-    re_path(serve_pattern, cache_page(wagtail_views.serve), name='wagtail_serve'),
+    # Wagtail
+    re_path(r'', include(wagtailcore_urls)),
 
 ]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'icalendar==4.0.*',
         'wagtail==2.4.*',
         'wagtailfontawesome>=1.1.3,<2.0',
-        'wagtail-cache==0.4.*',
+        'wagtail-cache==0.5.*',
         'wagtail-import-export>=0.1,<0.2'
     ],
     extras_require={


### PR DESCRIPTION
This upgrade fixes issue #118 and enhances caching by updating to wagtailcache 0.5 and using the new middleware by default.

Advantages:
* We can now remove duplicated wagtail URLs from urls.py
* New middleware caches 301/302 redirects and 404 pages.
* New middleware properly caches CSRF tokens so form pages should not need any additional logic.
