### PR TITLE
Fixing json syntax error on event markup

### DIFF
--- a/coderedcms/templates/coderedcms/includes/struct_data_event.json
+++ b/coderedcms/templates/coderedcms/includes/struct_data_event.json
@@ -40,7 +40,7 @@
     "name": "{{self.title}}",
     "address":{
       "@type": "PostalAddress",
-      "streetAddress": "{{self.address}}",
+      "streetAddress": "{{self.address}}"
     }
   },
   {% endif %}


### PR DESCRIPTION
Noticed that there was a minor syntax error causing google structured data failure.