### PR TITLE
ugettext_lazy to getext_lazy

### DIFF
--- a/coderedcms/blocks/__init__.py
+++ b/coderedcms/blocks/__init__.py
@@ -4,7 +4,7 @@ individual files based on purpose, but provide them all as a
 single `blocks` module.
 """
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .base_blocks import * #noqa
 from .html_blocks import * #noqa


### PR DESCRIPTION
this seems deprecated in new django, so looking for cleaning up all ugettext_lazy