### PR TITLE
Highlight active navbar links

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/base_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/base_link_block.html
@@ -1,48 +1,59 @@
 {% load coderedcms_tags wagtailcore_tags wagtailimages_tags %}
 
 {% block menu_item %}
+    {% if value.page.live or value.link or value.document %}
     {% is_menu_item_dropdown value as has_dropdown %}
-    {% if value.page %}{% is_active_page page value.page request as is_active_url %}{% endif %}
-    {% block test %}{% endblock %}
-    <a href="{% block url %}#{% endblock %}"
-    {% if value.settings.custom_id %}id="{{value.settings.custom_id}}"{% endif %}
-    class="{{aclass}} {% if has_dropdown %}dropdown-toggle{% endif %} {% if is_active_url %}active{% endif %} {% if value.settings.custom_css_class %}{{value.settings.custom_css_class}}{% endif %}"
-    {% if has_dropdown %}data-toggle="dropdown"
-    role="button"
-    aria-haspopup="true"
-    aria-expanded="false"
-    {% endif %}
-    {% if ga_event_label %}
-    data-ga-event-label="{{ ga_event_label }}"
-    {% endif %}
-    {% if ga_event_category %}
-    data-ga-event-category="{{ ga_event_category }}"
-    {% endif %}
-    >
-        {% if value.image %}
-            {% image value.image max-200x200 as img %}
-            <img src="{{img.url}}" class="w-100" alt="{{img.image.title}}"/>
-        {% elif value.display_text %}
-            {{value.display_text|safe}}
-        {% elif value.page %}
-            {{value.page.title}}
-        {% elif value.document %}
-            {{value.document.title}}
+    <li class="nav-item {% if has_dropdown %}dropdown{% endif %}">
+        {% is_active_page page value.page request as is_active_url %}
+        <a href="{% block url %}#{% endblock %}"
+        {% if value.settings.custom_id %}id="{{value.settings.custom_id}}"{% endif %}
+        class="nav-link {% if has_dropdown %}dropdown-toggle{% endif %} {% if is_active_url %}active{% endif %} {% if value.settings.custom_css_class %}{{value.settings.custom_css_class}}{% endif %}"
+        {% if has_dropdown %}data-toggle="dropdown"
+        role="button"
+        aria-haspopup="true"
+        aria-expanded="false"
         {% endif %}
-    </a>
+        {% if ga_event_label %}
+        data-ga-event-label="{{ ga_event_label }}"
+        {% endif %}
+        {% if ga_event_category %}
+        data-ga-event-category="{{ ga_event_category }}"
+        {% endif %}
+        >
+            {% if value.image %}
+                {% image value.image max-200x200 as img %}
+                <img src="{{img.url}}" class="w-100" alt="{{img.image.title}}"/>
+            {% elif value.display_text %}
+                {{value.display_text|safe}}
+            {% elif value.page %}
+                {{value.page.title}}
+            {% elif value.document %}
+                {{value.document.title}}
+            {% endif %}
+        </a>
 
 
-    {% if has_dropdown %}
-    <ul class="dropdown-menu">
-        {% for sub_link in value.sub_links %}
-            <li>{% include_block sub_link with aclass="dropdown-item" %}</li>
-        {% endfor %}
-        {% if value.show_child_links %}
-            {% for child in value.page.specific.get_index_children %}
-                <li><a class="dropdown-item" href="{% pageurl child %}">{{child.title}}</a></li>
+        {% if has_dropdown %}
+        <ul class="dropdown-menu">
+            {% for sub_link in value.sub_links %}
+                {% is_active_page page sub_link.page request as is_active_sub %}
+                <li>
+                    {% if is_active_sub %}
+                        {% include_block sub_link with aclass="dropdown-item active" %}
+                    {% else %}
+                        {% include_block sub_link with aclass="dropdown-item" %}
+                    {% endif %}
+                </li>
             {% endfor %}
+            {% if value.show_child_links %}
+                {% for child in value.page.specific.get_index_children %}
+                    {% is_active_page page child request as is_active_child %}
+                    <li><a class="dropdown-item {% if is_active_child %}active{% endif %}" href="{% pageurl child %}">{{child.title}}</a></li>
+                {% endfor %}
+            {% endif %}
+        </ul>
         {% endif %}
-    </ul>
+    </li>
     {% endif %}
 
 {% endblock %}

--- a/coderedcms/templates/coderedcms/blocks/base_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/base_link_block.html
@@ -1,11 +1,12 @@
-{% load wagtailcore_tags wagtailimages_tags coderedcms_tags %}
+{% load coderedcms_tags wagtailcore_tags wagtailimages_tags %}
 
 {% block menu_item %}
     {% is_menu_item_dropdown value as has_dropdown %}
-
+    {% if value.page %}{% is_active_page page value.page request as is_active_url %}{% endif %}
+    {% block test %}{% endblock %}
     <a href="{% block url %}#{% endblock %}"
     {% if value.settings.custom_id %}id="{{value.settings.custom_id}}"{% endif %}
-    class="{{aclass}} {% if has_dropdown %}dropdown-toggle{% endif %} {% if value.settings.custom_css_class %}{{value.settings.custom_css_class}}{% endif %}"
+    class="{{aclass}} {% if has_dropdown %}dropdown-toggle{% endif %} {% if is_active_url %}active{% endif %} {% if value.settings.custom_css_class %}{{value.settings.custom_css_class}}{% endif %}"
     {% if has_dropdown %}data-toggle="dropdown"
     role="button"
     aria-haspopup="true"

--- a/coderedcms/templates/coderedcms/blocks/base_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/base_link_block.html
@@ -3,11 +3,11 @@
 {% block menu_item %}
     {% if value.page.live or value.link or value.document %}
     {% is_menu_item_dropdown value as has_dropdown %}
-    <li class="nav-item {% if has_dropdown %}dropdown{% endif %}">
+    <li class="{{liclass}} {% if has_dropdown %}dropdown{% endif %}">
         {% is_active_page page value.page request as is_active_url %}
         <a href="{% block url %}#{% endblock %}"
         {% if value.settings.custom_id %}id="{{value.settings.custom_id}}"{% endif %}
-        class="nav-link {% if has_dropdown %}dropdown-toggle{% endif %} {% if is_active_url %}active{% endif %} {% if value.settings.custom_css_class %}{{value.settings.custom_css_class}}{% endif %}"
+        class="{{aclass}} {% if has_dropdown %}dropdown-toggle{% endif %} {% if is_active_url %}active{% endif %} {% if value.settings.custom_css_class %}{{value.settings.custom_css_class}}{% endif %}"
         {% if has_dropdown %}data-toggle="dropdown"
         role="button"
         aria-haspopup="true"
@@ -36,14 +36,7 @@
         {% if has_dropdown %}
         <ul class="dropdown-menu">
             {% for sub_link in value.sub_links %}
-                {% is_active_page page sub_link.page request as is_active_sub %}
-                <li>
-                    {% if is_active_sub %}
-                        {% include_block sub_link with aclass="dropdown-item active" %}
-                    {% else %}
-                        {% include_block sub_link with aclass="dropdown-item" %}
-                    {% endif %}
-                </li>
+                {% include_block sub_link with liclass="" aclass="dropdown-item" %}
             {% endfor %}
             {% if value.show_child_links %}
                 {% for child in value.page.specific.get_index_children %}

--- a/coderedcms/templates/coderedcms/snippets/navbar.html
+++ b/coderedcms/templates/coderedcms/snippets/navbar.html
@@ -34,10 +34,7 @@
       <ul class="navbar-nav {% if navbar.custom_css_class %}{{navbar.custom_css_class}}{% endif %}"
         {% if navbar.custom_id %}id="{{navbar.custom_id}}"{% endif %} >
         {% for item in navbar.menu_items %}
-          {% if item.value.page.live %}
-            {% is_menu_item_dropdown item.value as has_dropdown %}
-            <li class="nav-item {% if has_dropdown %}dropdown{% endif %}">{% include_block item with aclass="nav-link" ga_event_category="Navbar" %}</li>
-          {% endif %}
+            {% include_block item with ga_event_category="Navbar" %}
         {% endfor %}
       </ul>
       {% endfor %}

--- a/coderedcms/templates/coderedcms/snippets/navbar.html
+++ b/coderedcms/templates/coderedcms/snippets/navbar.html
@@ -34,7 +34,7 @@
       <ul class="navbar-nav {% if navbar.custom_css_class %}{{navbar.custom_css_class}}{% endif %}"
         {% if navbar.custom_id %}id="{{navbar.custom_id}}"{% endif %} >
         {% for item in navbar.menu_items %}
-            {% include_block item with ga_event_category="Navbar" %}
+            {% include_block item with liclass="nav-item" aclass="nav-link" ga_event_category="Navbar" %}
         {% endfor %}
       </ul>
       {% endfor %}

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -65,9 +65,12 @@ def is_menu_item_dropdown(value):
 
 @register.simple_tag
 def is_active_page(curr_page, other_page, request):
-    curr_url = curr_page.get_url(request)
-    other_url = other_page.get_url(request)
-    return curr_url == other_url
+    try:
+        curr_url = curr_page.get_url(request)
+        other_url = other_page.get_url(request)
+        return curr_url == other_url
+    except:
+        return False
 
 @register.simple_tag
 def get_pictures(collection_id):

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -64,6 +64,12 @@ def is_menu_item_dropdown(value):
         )
 
 @register.simple_tag
+def is_active_page(curr_page, other_page, request):
+    curr_url = curr_page.get_url(request)
+    other_url = other_page.get_url(request)
+    return curr_url == other_url
+
+@register.simple_tag
 def get_pictures(collection_id):
     collection = Collection.objects.get(id=collection_id)
     return Image.objects.filter(collection=collection)
@@ -134,6 +140,6 @@ def richtext_amp(value):
         value = richtext(value.source)
     else:
         value = richtext(value)
-    
+
     value = utils.convert_to_amp(value)
     return mark_safe(value)


### PR DESCRIPTION
Adds an `active` CSS class to page links in the navbar when on that same page.

Also fixed bug where non-pages would not render in the top level navbar (due to `{% if item.value.page.live %}` check)