### PR TITLE
adding language to html tag and i18n

### DIFF
--- a/coderedcms/project_template/project_name/settings/base.py
+++ b/coderedcms/project_template/project_name/settings/base.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+from django.utils.translation import gettext_lazy as _
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -142,8 +143,10 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/{{ docs_version }}/topics/i18n/
 
 # To add or change language of the project, modify the list below.
+LANGUAGE_CODE = 'en-us'
+
 LANGUAGES = [
-    ('en', _('English'))
+    ('en-us', _('English'))
 ]
 
 TIME_ZONE = 'America/New_York'

--- a/coderedcms/project_template/project_name/settings/base.py
+++ b/coderedcms/project_template/project_name/settings/base.py
@@ -138,15 +138,17 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/{{ docs_version }}/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+# To add or change language of the project, modify the list below.
+LANGUAGES = [
+    ('en', _('English'))
+]
 
 TIME_ZONE = 'America/New_York'
 
-USE_I18N = False
+USE_I18N = True
 
 USE_L10N = True
 

--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -1,8 +1,11 @@
 {% load static coderedcms_tags i18n wagtailcore_tags wagtailimages_tags wagtailsettings_tags wagtailuserbar %}
 {% get_settings %}
+{% load i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+
 
 <!doctype html>
-<html prefix="og: http://ogp.me/ns#">
+<html prefix="og: http://ogp.me/ns#" lang="{{ LANGUAGE_CODE }}">
   <head>
         {% block tracking %}
         {% if settings.coderedcms.AnalyticsSettings.ga_tracking_id %}

--- a/coderedcms/tests/settings.py
+++ b/coderedcms/tests/settings.py
@@ -143,11 +143,13 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/{{ docs_version }}/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGES = [
+    ('en', _('English')),
+]
 
 TIME_ZONE = 'America/New_York'
 
-USE_I18N = False
+USE_I18N = True
 
 USE_L10N = True
 

--- a/coderedcms/tests/settings.py
+++ b/coderedcms/tests/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+from django.utils.translation import gettext_lazy as _
+
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -143,8 +145,10 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/{{ docs_version }}/topics/i18n/
 
+LANGUAGE_CODE = 'en-us'
+
 LANGUAGES = [
-    ('en', _('English')),
+    ('en-us', _('English')),
 ]
 
 TIME_ZONE = 'America/New_York'

--- a/docs/getting_started/customize_develop.rst
+++ b/docs/getting_started/customize_develop.rst
@@ -35,3 +35,23 @@ affect the caching decision. For example::
         if 'nocache' in request.GET:
             return False
 
+
+Default Language
+----------------
+
+To adjust the default language of a project, navigate to Project_Name/Project_Name/settings/base.py. Change both the
+LANGUAGE_CODE setting and the LANGUAGES setting. For example::
+
+        LANGUAGE_CODE = 'es'
+
+        LANGUAGES = [
+            ('es', _('Spanish'))
+        ]
+
+Note that these settings are both in use to communicate to the users' browser about the default language of the project.
+This ensures that users requiring assistive technology have a smooth experience using the site. These settings do not,
+on their own, translate or enable multiple languages on the project.
+
+`For a full list of language codes, see this list from W3 Docs. <https://www.w3docs.com/learn-html/html-language-codes.html>`_
+
+


### PR DESCRIPTION
in settings.py
-changed i18n to True so that international users can access admin in preferred language

in base.py
-changed LANGUAGE_CODE to LANGUAGES list with tuples of possible project languages (leaving 'en' as default)
- to change the default page language, remove the 'en' tuple and add in your preferred language

in base.html
-used i18n to get_current_language from user's browser, and if it is one of the languages in LANGUAGES in base.py, the browser will use that language in the html tags
-if user's current language is not available to that project, the language set in base.py will stay set in the html tags

[django translation doc](https://docs.djangoproject.com/en/2.2/topics/i18n/translation/)