### PR TITLE
Feature/196 title iframe blocks

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/embed_video_block.html
+++ b/coderedcms/templates/coderedcms/blocks/embed_video_block.html
@@ -1,5 +1,12 @@
 {% extends "coderedcms/blocks/base_block.html" %}
+{% load coderedcms_tags %}
 
 {% block block_render %}
-{{self.url}}
+
+{% if format == 'amp' %}
+    {{ self.url.html|amp_formatting }}
+{% else %}
+    {{ self.url }}
+{% endif %}
+
 {% endblock %}

--- a/coderedcms/templates/coderedcms/blocks/rich_text_block.html
+++ b/coderedcms/templates/coderedcms/blocks/rich_text_block.html
@@ -3,7 +3,7 @@
 {% block block_render %}
 
 {% if format == 'amp' %}
-{{ self|richtext_amp }}
+{{ self|richtext_amp_formatting }}
 {% else %}
 {{ self|richtext }}
 {% endif %}

--- a/coderedcms/templates/coderedcms/pages/base.amp.html
+++ b/coderedcms/templates/coderedcms/pages/base.amp.html
@@ -208,6 +208,7 @@
     </style>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   </head>
   <body>
     {% block amp_nav %}

--- a/coderedcms/templates/wagtailembeds/embed_frontend.html
+++ b/coderedcms/templates/wagtailembeds/embed_frontend.html
@@ -1,4 +1,4 @@
-{% load wagtailembeds_tags coderedcms_tags %}
+{% load coderedcms_tags %}
 
 {% if embed.ratio %}
     {# If an aspect ratio is included, use the appropriate Bootstrap 4 class #}

--- a/coderedcms/templates/wagtailembeds/embed_frontend.html
+++ b/coderedcms/templates/wagtailembeds/embed_frontend.html
@@ -1,4 +1,4 @@
-{% load wagtailembeds_tags %}
+{% load wagtailembeds_tags coderedcms_tags %}
 
 {% if embed.ratio %}
     {# If an aspect ratio is included, use the appropriate Bootstrap 4 class #}
@@ -16,6 +16,5 @@
     <div class="row justify-content-center">
 {% endif %}
 
-{# Embed the video with an absurdly high max width. #}
-{% embed embed.url max_width=3840 %}
+{% render_iframe_from_embed embed %}
 </div>

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -147,5 +147,7 @@ def render_iframe_from_embed(embed):
         return mark_safe(str(soup.body.iframe))
     except AttributeError:
         pass
+    except TypeError:
+        pass
 
-    return embed.html
+    return mark_safe(embed.html)

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -1,13 +1,11 @@
 import string
 import random
-from html import unescape
 
 from bs4 import BeautifulSoup
 from datetime import datetime
 from django import template
 from django.conf import settings
 from django.forms import ClearableFileInput
-from django.utils import timezone
 from django.utils.html import mark_safe
 from wagtail.core.models import Collection
 from wagtail.core.rich_text import RichText
@@ -22,30 +20,36 @@ from coderedcms.settings import cr_settings, get_bootstrap_setting
 
 register = template.Library()
 
+
 @register.filter
 def is_advanced_setting(obj):
     return CoderedAdvSettings in (obj.__class__,) + obj.__class__.__bases__
+
 
 @register.filter
 def is_file_form(form):
     return any([isinstance(field.field.widget, ClearableFileInput) for field in form])
 
+
 @register.simple_tag
 def coderedcms_version():
     return __version__
 
+
 @register.simple_tag
 def generate_random_id():
     return ''.join(random.choice(string.ascii_letters + string.digits) for n in range(20))
+
 
 @register.simple_tag
 def is_menu_item_dropdown(value):
     return \
         len(value.get('sub_links', [])) > 0 or \
         (
-            value.get('show_child_links', False) and \
+            value.get('show_child_links', False) and
             len(value.get('page', []).get_children().live()) > 0
         )
+
 
 @register.simple_tag(takes_context=True)
 def is_active_page(context, curr_page, other_page):
@@ -55,18 +59,22 @@ def is_active_page(context, curr_page, other_page):
         return curr_url == other_url
     return False
 
+
 @register.simple_tag
 def get_pictures(collection_id):
     collection = Collection.objects.get(id=collection_id)
     return Image.objects.filter(collection=collection)
 
+
 @register.simple_tag
 def get_navbars():
     return Navbar.objects.all()
 
+
 @register.simple_tag
 def get_footers():
     return Footer.objects.all()
+
 
 @register.simple_tag
 def get_searchform(request=None):
@@ -74,9 +82,11 @@ def get_searchform(request=None):
         return SearchForm(request.GET)
     return SearchForm()
 
+
 @register.simple_tag
 def get_pageform(page, request):
     return page.get_form(page=page, user=request.user)
+
 
 @register.simple_tag
 def process_form_cell(request, cell):
@@ -86,17 +96,21 @@ def process_form_cell(request, cell):
         return mark_safe("<a href='{0}'>{1}</a>".format(cell, cell))
     return cell
 
+
 @register.filter
 def codered_settings(value):
     return cr_settings.get(value, None)
+
 
 @register.filter
 def bootstrap_settings(value):
     return get_bootstrap_setting(value)
 
+
 @register.filter
 def django_settings(value):
     return getattr(settings, value)
+
 
 @register.simple_tag
 def query_update(querydict, key=None, value=None):
@@ -114,6 +128,7 @@ def query_update(querydict, key=None, value=None):
                 pass
     return get
 
+
 @register.filter
 def structured_data_datetime(dt):
     """
@@ -123,9 +138,11 @@ def structured_data_datetime(dt):
         return datetime.strftime(dt, "%Y-%m-%dT%H:%M")
     return datetime.strftime(dt, "%Y-%m-%d")
 
+
 @register.filter
 def amp_formatting(value):
     return mark_safe(utils.convert_to_amp(value))
+
 
 @register.filter
 def richtext_amp_formatting(value):
@@ -136,6 +153,7 @@ def richtext_amp_formatting(value):
         value = richtext(value)
 
     return amp_formatting(value)
+
 
 @register.simple_tag
 def render_iframe_from_embed(embed):

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -124,6 +124,10 @@ def structured_data_datetime(dt):
     return datetime.strftime(dt, "%Y-%m-%d")
 
 @register.filter
+def amp_formatting(value):
+    return mark_safe(utils.convert_to_amp(value))
+
+@register.filter
 def richtext_amp_formatting(value):
 
     if isinstance(value, RichText):
@@ -131,20 +135,15 @@ def richtext_amp_formatting(value):
     else:
         value = richtext(value)
 
-    value = utils.convert_to_amp(value)
-    return mark_safe(value)
-
-@register.filter
-def amp_formatting(value):
-    return mark_safe(utils.convert_to_amp(value))
+    return amp_formatting(value)
 
 @register.simple_tag
 def render_iframe_from_embed(embed):
-    soup = BeautifulSoup(embed.html, "html5lib")
+    soup = BeautifulSoup(embed.html, "html.parser")
     try:
         iframe_tags = soup.find('iframe')
         iframe_tags['title'] = embed.title
-        return mark_safe(str(soup.body.iframe))
+        return mark_safe(soup.prettify())
     except AttributeError:
         pass
     except TypeError:

--- a/coderedcms/utils.py
+++ b/coderedcms/utils.py
@@ -44,7 +44,7 @@ def convert_to_amp(value):
     Function that converts non-amp compliant html to valid amp html.
     value must be a string
     """
-    soup = BeautifulSoup(value, "html5lib")
+    soup = BeautifulSoup(value, "html.parser")
 
     #Replace img tags with amp-img
     try:

--- a/coderedcms/utils.py
+++ b/coderedcms/utils.py
@@ -44,12 +44,21 @@ def convert_to_amp(value):
     Function that converts non-amp compliant html to valid amp html.
     value must be a string
     """
-    soup = BeautifulSoup(value)
+    soup = BeautifulSoup(value, "html5lib")
 
     #Replace img tags with amp-img
     try:
         img_tags = soup.find('img')
         img_tags.name = 'amp-img'
+    except AttributeError:
+        pass
+
+    # Replace iframe tags with amp-iframe
+    try:
+        iframe_tags = soup.find('iframe')
+        iframe_tags.name = 'amp-iframe'
+        iframe_tags['layout'] = 'responsive'
+
     except AttributeError:
         pass
 

--- a/coderedcms/utils.py
+++ b/coderedcms/utils.py
@@ -46,7 +46,7 @@ def convert_to_amp(value):
     """
     soup = BeautifulSoup(value, "html.parser")
 
-    #Replace img tags with amp-img
+    # Replace img tags with amp-img
     try:
         img_tags = soup.find('img')
         img_tags.name = 'amp-img'


### PR DESCRIPTION
Fixes #196 

From embedly, we receive the html of the embed and the title of the embed's web page.  Before rendering the html, we use beautifulsoup to inject the title tag into the iframe.

Also removes two unused templatetags and creates almost amp compliant iframes.