### PR TITLE
twitter card adjusted to render images

### DIFF
--- a/coderedcms/templates/coderedcms/pages/article_page.html
+++ b/coderedcms/templates/coderedcms/pages/article_page.html
@@ -30,7 +30,6 @@
 {% if settings.coderedcms.SeoSettings.twitter_meta %}
     {% block twitter_card %}{% if self.cover_image %}summary_large_image{% else %}{{block.super}}{% endif %}{% endblock %}
     {% block twitter_seo_extra %}
-    {% image self.cover_image fill-2000x1000 as cover_image %}
         <meta name="twitter:title" content="{{ self.title }}">
         {% if self.caption %}
         <meta name="twitter:description" content="{{ self.caption }}">

--- a/coderedcms/templates/coderedcms/pages/article_page.html
+++ b/coderedcms/templates/coderedcms/pages/article_page.html
@@ -30,11 +30,9 @@
 {% if settings.coderedcms.SeoSettings.twitter_meta %}
     {% block twitter_card %}{% if self.cover_image %}summary_large_image{% else %}{{block.super}}{% endif %}{% endblock %}
     {% block twitter_seo_extra %}
-        <meta name="twitter:title" content="{{ self.title }}">
         {% if self.caption %}
         <meta name="twitter:description" content="{{ self.caption }}">
         {% endif %}
-        <meta name="twitter:image" content="{{self.get_site.root_url}}{{ twitter_card_image self }}">
         {% if self.author.twitter %}
             <meta name="twitter:creator" content="{{self.author.twitter}}" />
         {% endif %}

--- a/coderedcms/templates/coderedcms/pages/article_page.html
+++ b/coderedcms/templates/coderedcms/pages/article_page.html
@@ -32,8 +32,10 @@
     {% block twitter_seo_extra %}
     {% image self.cover_image fill-2000x1000 as cover_image %}
         <meta name="twitter:title" content="{{ self.title }}">
+        {% if self.caption %}
         <meta name="twitter:description" content="{{ self.caption }}">
-        <meta name="twitter:image" content="{{self.get_site.root_url}}{{ cover_image.url }}">
+        {% endif %}
+        <meta name="twitter:image" content="{{self.get_site.root_url}}{{ twitter_card_image self }}">
         {% if self.author.twitter %}
             <meta name="twitter:creator" content="{{self.author.twitter}}" />
         {% endif %}

--- a/coderedcms/templates/coderedcms/pages/article_page.html
+++ b/coderedcms/templates/coderedcms/pages/article_page.html
@@ -30,6 +30,10 @@
 {% if settings.coderedcms.SeoSettings.twitter_meta %}
     {% block twitter_card %}{% if self.cover_image %}summary_large_image{% else %}{{block.super}}{% endif %}{% endblock %}
     {% block twitter_seo_extra %}
+    {% image self.cover_image fill-2000x1000 as cover_image %}
+        <meta name="twitter:title" content="{{ self.title }}">
+        <meta name="twitter:description" content="{{ self.caption }}">
+        <meta name="twitter:image" content="{{self.get_site.root_url}}{{ cover_image.url }}">
         {% if self.author.twitter %}
             <meta name="twitter:creator" content="{{self.author.twitter}}" />
         {% endif %}

--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -42,18 +42,7 @@
             <meta property="og:site_name" content="{% block og_site_name %}{{self.get_site.site_name}}{% endblock %}" />
             <meta property="og:type" content="{% block og_type %}website{% endblock %}" />
             <meta property="og:url" content="{% block og_url %}{{self.get_full_url}}{% endblock %}" />
-            <meta property="og:image" content="{% block og_image %}
-                {% if self.og_image %}
-                    {% image self.og_image original as og_logo %}
-                    {{og_logo.url}}
-                {% elif self.cover_image %}
-                    {% image self.cover_image original as og_logo %}
-                    {{og_logo.url}}
-                {% elif settings.coderedcms.LayoutSettings.logo %}
-                    {% image settings.coderedcms.LayoutSettings.logo original as og_logo %}
-                    {{og_logo.url}}
-                {% endif %}
-                {% endblock %}" />
+            <meta property="og:image" content="{% block og_image %}{% og_image self %}{% endblock %}" />
             {% endblock %}
             {% block og_seo_extra %}{% endblock %}
         {% endif %}
@@ -62,7 +51,8 @@
         {% if settings.coderedcms.SeoSettings.twitter_meta %}
             {% block twitter_seo_base %}
             <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}" />
-            <meta name="twitter:image" content="{% twitter_card_image self %}">
+            <meta name="twitter:title" content="{{self.title}}">
+            <meta name="twitter:image" content="{{self.get_site.root_url}}{% twitter_card_image self %}">
             {% if settings.coderedcms.SocialMediaSettings.twitter %}
             <meta name="twitter:site" content="{% block twitter_site %}@{{settings.coderedcms.SocialMediaSettings.twitter_handle}}{% endblock %}" />
             {% endif %}

--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -62,6 +62,7 @@
         {% if settings.coderedcms.SeoSettings.twitter_meta %}
             {% block twitter_seo_base %}
             <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}" />
+            <meta name="twitter:image" content="{% twitter_card_image self %}">
             {% if settings.coderedcms.SocialMediaSettings.twitter %}
             <meta name="twitter:site" content="{% block twitter_site %}@{{settings.coderedcms.SocialMediaSettings.twitter_handle}}{% endblock %}" />
             {% endif %}

--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -52,7 +52,7 @@
             {% block twitter_seo_base %}
             <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}" />
             <meta name="twitter:title" content="{{self.title}}">
-            <meta name="twitter:image" content="{{self.get_site.root_url}}{% twitter_card_image self %}">
+            <meta name="twitter:image" content="{% og_image self %}">
             {% if settings.coderedcms.SocialMediaSettings.twitter %}
             <meta name="twitter:site" content="{% block twitter_site %}@{{settings.coderedcms.SocialMediaSettings.twitter_handle}}{% endblock %}" />
             {% endif %}

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -10,7 +10,7 @@ from django.utils.html import mark_safe
 from wagtail.core.models import Collection
 from wagtail.core.rich_text import RichText
 from wagtail.core.templatetags.wagtailcore_tags import richtext
-from wagtail.images.models import Image, Rendition
+from wagtail.images.models import Image
 
 from coderedcms import utils, __version__
 from coderedcms.blocks import CoderedAdvSettings

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -40,6 +40,12 @@ def coderedcms_version():
 def generate_random_id():
     return ''.join(random.choice(string.ascii_letters + string.digits) for n in range(20))
 
+@register.simple_tag
+def twitter_card_image(self):
+    if self.cover_image:
+        return self.cover_image
+    elif settings.coderedcms.LayoutSettings.logo:
+        return settings.coderedcms.LayoutSettings.logo
 
 @register.simple_tag
 def is_menu_item_dropdown(value):

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -7,7 +7,7 @@ from django import template
 from django.conf import settings
 from django.forms import ClearableFileInput
 from django.utils.html import mark_safe
-from wagtail.core.models import Collection, Page
+from wagtail.core.models import Collection
 from wagtail.core.rich_text import RichText
 from wagtail.core.templatetags.wagtailcore_tags import richtext
 from wagtail.images.models import Image

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -10,13 +10,14 @@ from django.utils.html import mark_safe
 from wagtail.core.models import Collection
 from wagtail.core.rich_text import RichText
 from wagtail.core.templatetags.wagtailcore_tags import richtext
-from wagtail.images.models import Image
+from wagtail.images.models import Image, Rendition
 
 from coderedcms import utils, __version__
 from coderedcms.blocks import CoderedAdvSettings
 from coderedcms.forms import SearchForm
 from coderedcms.models import Footer, Navbar
 from coderedcms.settings import cr_settings, get_bootstrap_setting
+from coderedcms.models.wagtailsettings_models import LayoutSettings
 
 register = template.Library()
 
@@ -40,12 +41,26 @@ def coderedcms_version():
 def generate_random_id():
     return ''.join(random.choice(string.ascii_letters + string.digits) for n in range(20))
 
-@register.simple_tag
-def twitter_card_image(self):
-    if self.cover_image:
-        return self.cover_image
-    elif settings.coderedcms.LayoutSettings.logo:
-        return settings.coderedcms.LayoutSettings.logo
+@register.simple_tag(takes_context=True)
+def twitter_card_image(context, page):
+    if page.cover_image:
+        print("cover image")
+        return page.cover_image.get_rendition('original').url
+    elif LayoutSettings.for_site(context['request'].site).logo:
+        layout_settings = LayoutSettings.for_site(context['request'].site)
+        print("layout settings logo")
+        return layout_settings.logo.get_rendition('original').url
+
+@register.simple_tag(takes_context=True)
+def og_image(context, page):
+    if page.og_image:
+        return page.og_image.get_rendition('original').url
+    elif page.cover_image:
+        return page.cover_image.get_rendition('original').url
+    elif LayoutSettings.for_site(context['request'].site).logo:
+        layout_settings = LayoutSettings.for_site(context['request'].site)
+        return layout_settings.logo.get_rendition('original').url
+
 
 @register.simple_tag
 def is_menu_item_dropdown(value):

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -41,6 +41,7 @@ def coderedcms_version():
 def generate_random_id():
     return ''.join(random.choice(string.ascii_letters + string.digits) for n in range(20))
 
+
 @register.simple_tag(takes_context=True)
 def og_image(context, page):
     site_url = context['request'].site.root_url

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -7,7 +7,7 @@ from django import template
 from django.conf import settings
 from django.forms import ClearableFileInput
 from django.utils.html import mark_safe
-from wagtail.core.models import Collection
+from wagtail.core.models import Collection, Page
 from wagtail.core.rich_text import RichText
 from wagtail.core.templatetags.wagtailcore_tags import richtext
 from wagtail.images.models import Image
@@ -42,24 +42,16 @@ def generate_random_id():
     return ''.join(random.choice(string.ascii_letters + string.digits) for n in range(20))
 
 @register.simple_tag(takes_context=True)
-def twitter_card_image(context, page):
-    if page.cover_image:
-        print("cover image")
-        return page.cover_image.get_rendition('original').url
-    elif LayoutSettings.for_site(context['request'].site).logo:
-        layout_settings = LayoutSettings.for_site(context['request'].site)
-        print("layout settings logo")
-        return layout_settings.logo.get_rendition('original').url
-
-@register.simple_tag(takes_context=True)
 def og_image(context, page):
+    site_url = context['request'].site.root_url
     if page.og_image:
-        return page.og_image.get_rendition('original').url
+        relative_path = page.og_image.get_rendition('original').url
     elif page.cover_image:
-        return page.cover_image.get_rendition('original').url
+        relative_path = page.cover_image.get_rendition('original').url
     elif LayoutSettings.for_site(context['request'].site).logo:
         layout_settings = LayoutSettings.for_site(context['request'].site)
-        return layout_settings.logo.get_rendition('original').url
+        relative_path = layout_settings.logo.get_rendition('original').url
+    return site_url + relative_path
 
 
 @register.simple_tag

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -51,6 +51,8 @@ def og_image(context, page):
     elif LayoutSettings.for_site(context['request'].site).logo:
         layout_settings = LayoutSettings.for_site(context['request'].site)
         relative_path = layout_settings.logo.get_rendition('original').url
+    else:
+        return None
     return site_url + relative_path
 
 


### PR DESCRIPTION
- added meta tags to base to comply with twitter requirements and called up new template tag, twitter_card_image
- twitter_card_image first tries to use cover image in twitter card, if not uses website logo
- per request, cleaned up the Open Graph image meta tag logic to check for OG image, then cover photo, then logo in the same way as the twitter_card_image.
- article page runs also runs twitter_card_image and adjusts the twitter card to use summary_large_image

