### PR TITLE
Cleanup whitespace in HTML templates

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/base_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/base_link_block.html
@@ -7,7 +7,7 @@
         {% is_active_page page value.page as is_active_url %}
         <a href="{% block url %}#{% endblock %}"
         {% if value.settings.custom_id %}id="{{value.settings.custom_id}}"{% endif %}
-        class="{{aclass}} {% if has_dropdown %}dropdown-toggle{% endif %} {% if is_active_url %}active{% endif %} {% if value.settings.custom_css_class %}{{value.settings.custom_css_class}}{% endif %}"
+        class="{{aclass}} {% if has_dropdown %}dropdown-toggle{% endif %} {% if is_active_url %}active{% endif %} {{value.settings.custom_css_class}}"
         {% if has_dropdown %}data-toggle="dropdown"
         role="button"
         aria-haspopup="true"

--- a/coderedcms/templates/coderedcms/blocks/button_block.html
+++ b/coderedcms/templates/coderedcms/blocks/button_block.html
@@ -1,16 +1,14 @@
 <a href="{{self.url}}"
-	{% if settings.coderedcms.AnalyticsSettings.ga_track_button_clicks and not format == 'amp' %}
+    {% if settings.coderedcms.AnalyticsSettings.ga_track_button_clicks and not format == 'amp' %}
         data-ga-event-category='{{self.settings.ga_tracking_event_category|default:"Button"}}'
         data-ga-event-label='{{self.settings.ga_tracking_event_label|default:self.button_title}}'
-	{% endif %}
+    {% endif %}
   title="{{ self.button_title|safe }}"
   class="btn {{ self.button_style }} {{ self.button_size }} {{ self.settings.custom_css_class }}"
   {% if self.settings.custom_id %}id="{{ self.settings.custom_id }}"{% endif %}>
-	{% if self.button_title %}
-		{{ self.button_title|safe }}
-	{% else %}
-		{{ self.url }}
-	{% endif %}
+    {% if self.button_title %}
+        {{ self.button_title|safe }}
+    {% else %}
+        {{ self.url }}
+    {% endif %}
 </a>
-
-

--- a/coderedcms/templates/coderedcms/blocks/column_block.html
+++ b/coderedcms/templates/coderedcms/blocks/column_block.html
@@ -1,8 +1,6 @@
 {% load wagtailcore_tags %}
 
-<div class="col{% if self.settings.column_breakpoint %}-{{ self.settings.column_breakpoint }}{% endif %}{% if self.column_size %}-{{ self.column_size }}{% endif %}
-{{self.settings.custom_css_class}}"
-{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
+<div {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %} class="col{% if self.settings.column_breakpoint %}-{{ self.settings.column_breakpoint }}{% endif %}{% if self.column_size %}-{{ self.column_size }}{% endif %} {{self.settings.custom_css_class}}">
       {% for block in self.content %}
       {% include_block block %}
       {% endfor %}

--- a/coderedcms/templates/coderedcms/blocks/document_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/document_link_block.html
@@ -1,7 +1,3 @@
 {% extends 'coderedcms/blocks/base_link_block.html' %}
 
-{% block url %}
-	{% if value.document %}
-    	{{value.document.url}}
-    {% endif %}
-{% endblock %}
+{% block url %}{% if value.document %}{{value.document.url}}{% endif %}{% endblock %}

--- a/coderedcms/templates/coderedcms/blocks/download_block.html
+++ b/coderedcms/templates/coderedcms/blocks/download_block.html
@@ -17,8 +17,8 @@
 
 {% if self.automatic_download and not format == 'amp' %}
 <script>
-	$(document).ready(function(){
-		window.open("{{self.downloadable_file.url}}", '_blank');
-	});
+    $(document).ready(function(){
+        window.open("{{self.downloadable_file.url}}", '_blank');
+    });
 </script>
 {% endif %}

--- a/coderedcms/templates/coderedcms/blocks/external_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/external_link_block.html
@@ -1,5 +1,3 @@
 {% extends 'coderedcms/blocks/base_link_block.html' %}
 
-{% block url %}
-    {{value.link}}
-{% endblock %}
+{% block url %}{{value.link}}{% endblock %}

--- a/coderedcms/templates/coderedcms/blocks/google_map.html
+++ b/coderedcms/templates/coderedcms/blocks/google_map.html
@@ -1,8 +1,8 @@
 <div class="embed-responsive embed-responsive-16by9 {{self.settings.custom_css_clas}}"
 {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
-	{% if self.place_id %}
-		<iframe class="embed-responsive-item" width="100%" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=place_id:{{ self.place_id }}&zoom={{ self.map_zoom_level }}&key={{ settings.GoogleApiSettings.google_maps_api_key}}" allowfullscreen></iframe>
-	{% else %}
-		<iframe class="embed-responsive-item" width="100%" style="border:0" src="https://maps.google.com/maps?q={{ self.search|urlencode }}&output=embed" allowfullscreen></iframe>
-	{% endif %}
+    {% if self.place_id %}
+        <iframe class="embed-responsive-item" width="100%" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=place_id:{{ self.place_id }}&zoom={{ self.map_zoom_level }}&key={{ settings.GoogleApiSettings.google_maps_api_key}}" allowfullscreen></iframe>
+    {% else %}
+        <iframe class="embed-responsive-item" width="100%" style="border:0" src="https://maps.google.com/maps?q={{ self.search|urlencode }}&output=embed" allowfullscreen></iframe>
+    {% endif %}
 </div>

--- a/coderedcms/templates/coderedcms/blocks/h1_block.html
+++ b/coderedcms/templates/coderedcms/blocks/h1_block.html
@@ -1,4 +1,4 @@
 <h1 {% if self.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
 {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
-	{{ self.text }}
+    {{ self.text }}
 </h1>

--- a/coderedcms/templates/coderedcms/blocks/h2_block.html
+++ b/coderedcms/templates/coderedcms/blocks/h2_block.html
@@ -1,4 +1,4 @@
 <h2 {% if self.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
 {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
-	{{ self.text }}
+    {{ self.text }}
 </h2>

--- a/coderedcms/templates/coderedcms/blocks/h3_block.html
+++ b/coderedcms/templates/coderedcms/blocks/h3_block.html
@@ -1,4 +1,4 @@
 <h3 {% if self.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
 {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
-	{{ self.text }}
+    {{ self.text }}
 </h3>

--- a/coderedcms/templates/coderedcms/blocks/hero_block.html
+++ b/coderedcms/templates/coderedcms/blocks/hero_block.html
@@ -5,14 +5,12 @@
 {% endif %}
 
 {% image self.background_image max-2000x2000 as background_image %}
-<div class="hero-bg {% if self.is_parallax %}parallax{% endif %} {% if self.tile_image %}tile{% endif %} {% if self.settings.custom_css_class %}{{self.settings.custom_css_class}}{% endif %}"
-	style="{% if self.background_color %}background-color:{{self.background_color}};{% endif %}
-		   {% if background_image %}background-image: url({{background_image.url}});{% endif %}"
-	{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
-	<div class="hero-fg"
-		style="{% if self.foreground_color %}color:{{self.foreground_color}};{% endif %}">
-		{% include_block self.content %}
-	</div>
+<div class="hero-bg {% if self.is_parallax %}parallax{% endif %} {% if self.tile_image %}tile{% endif %} {{self.settings.custom_css_class}}"
+    style="{% if self.background_color %}background-color:{{self.background_color}};{% endif %}{% if background_image %}background-image:url({{background_image.url}});{% endif %}"
+    {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+    <div class="hero-fg" style="{% if self.foreground_color %}color:{{self.foreground_color}};{% endif %}">
+        {% include_block self.content %}
+    </div>
 </div>
 
 {% if not self.fluid %}

--- a/coderedcms/templates/coderedcms/blocks/page_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/page_link_block.html
@@ -1,8 +1,4 @@
 {% extends 'coderedcms/blocks/base_link_block.html' %}
 {% load wagtailcore_tags %}
 
-{% block url %}
-	{% if value.page %}
-    	{% pageurl value.page %}
-    {% endif %}
-{% endblock %}
+{% block url %}{% if value.page %}{% pageurl value.page %}{% endif %}{% endblock %}

--- a/coderedcms/templates/coderedcms/includes/codered_banner.html
+++ b/coderedcms/templates/coderedcms/includes/codered_banner.html
@@ -1,6 +1,6 @@
 {% load coderedcms_tags %}
-		{% if "BANNER"|codered_settings %}
-        <div class="codered-banner" style="background-color:{{ 'BANNER_BACKGROUND'|codered_settings }}; color:{{ 'BANNER_TEXT_COLOR'|codered_settings }}; width:100%; padding:4px;">
-            {{ "BANNER"|codered_settings|safe }}
-        </div>
-        {% endif %}
+{% if "BANNER"|codered_settings %}
+<div class="codered-banner" style="background-color:{{ 'BANNER_BACKGROUND'|codered_settings }}; color:{{ 'BANNER_TEXT_COLOR'|codered_settings }}; width:100%; padding:4px;">
+    {{ "BANNER"|codered_settings|safe }}
+</div>
+{% endif %}

--- a/coderedcms/templates/coderedcms/includes/stream_forms/render_field.html
+++ b/coderedcms/templates/coderedcms/includes/stream_forms/render_field.html
@@ -3,7 +3,6 @@
 {% if block.value.settings.condition_trigger_id %}data-condition-trigger-id="{{ block.value.settings.condition_trigger_id }}"{% endif %}
 {% if block.value.settings.condition_trigger_value %}data-condition-trigger-value="{{ block.value.settings.condition_trigger_value }}"{% endif %}
 {% if block.value.settings.custom_id %}id="{{block.value.settings.custom_id}}"{% endif %}
-class="stream-form-input{% if block.value.settings.custom_css_class %} {{ block.value.settings.custom_css_class }}{% endif %}"
->
+class="stream-form-input {{ block.value.settings.custom_css_class }}">
 {% bootstrap_field field layout='horizontal' %}
 </div>

--- a/coderedcms/templates/coderedcms/pages/base.amp.html
+++ b/coderedcms/templates/coderedcms/pages/base.amp.html
@@ -212,12 +212,7 @@
   </head>
   <body>
     {% block amp_nav %}
-    <nav class="navbar
-        {% if settings.coderedcms.LayoutSettings.navbar_fixed %}fixed-top{% endif %}
-        {{settings.coderedcms.LayoutSettings.navbar_collapse_mode}}
-        {{settings.coderedcms.LayoutSettings.navbar_color_scheme}}
-        {{settings.coderedcms.LayoutSettings.navbar_class}}
-        {{settings.coderedcms.LayoutSettings.navbar_format}}" >
+    <nav class="navbar {% get_navbar_css %}">
         <a class="navbar-brand" href="/">
             {% if settings.coderedcms.LayoutSettings.logo %}
             {% image settings.coderedcms.LayoutSettings.logo max-300x50 as logo %}

--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -16,7 +16,6 @@
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-
               gtag('config', '{{settings.coderedcms.AnalyticsSettings.ga_tracking_id}}');
             </script>
         {% endif %}

--- a/coderedcms/templates/coderedcms/snippets/footer.html
+++ b/coderedcms/templates/coderedcms/snippets/footer.html
@@ -3,10 +3,7 @@
 
 {% get_footers as footers %}
 {% for footer in footers %}
-    <div
-        {% if footer.custom_id %} id="{{footer.custom_id}}"{% endif %}
-        {% if footer.custom_css_class %} class="{{footer.custom_css_class}}"{% endif %}
-    >
+    <div {% if footer.custom_id %} id="{{footer.custom_id}}"{% endif %} {% if footer.custom_css_class %} class="{{footer.custom_css_class}}"{% endif %}>
         {% for item in footer.content %}
             {% include_block item with format=format settings=settings %}
         {% endfor %}

--- a/coderedcms/templates/coderedcms/snippets/navbar.html
+++ b/coderedcms/templates/coderedcms/snippets/navbar.html
@@ -4,12 +4,7 @@
 <div class="container">
 {% endif %}
 
-<nav class="navbar
-  {% if settings.coderedcms.LayoutSettings.navbar_fixed %}fixed-top{% endif %}
-  {{settings.coderedcms.LayoutSettings.navbar_collapse_mode}}
-  {{settings.coderedcms.LayoutSettings.navbar_color_scheme}}
-  {{settings.coderedcms.LayoutSettings.navbar_class}}
-  {{settings.coderedcms.LayoutSettings.navbar_format}}" >
+<nav class="navbar {% get_navbar_css %}">
 
   {% if not settings.coderedcms.LayoutSettings.navbar_content_fluid %}
   <div class="container">
@@ -31,7 +26,7 @@
     <div class="collapse navbar-collapse" id="navbar">
       {% get_navbars as navbars %}
       {% for navbar in navbars %}
-      <ul class="navbar-nav {% if navbar.custom_css_class %}{{navbar.custom_css_class}}{% endif %}"
+      <ul class="navbar-nav {{navbar.custom_css_class}}"
         {% if navbar.custom_id %}id="{{navbar.custom_id}}"{% endif %} >
         {% for item in navbar.menu_items %}
             {% include_block item with liclass="nav-item" aclass="nav-link" ga_event_category="Navbar" %}

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -81,6 +81,19 @@ def get_pictures(collection_id):
     return Image.objects.filter(collection=collection)
 
 
+@register.simple_tag(takes_context=True)
+def get_navbar_css(context):
+    layout = LayoutSettings.for_site(context['request'].site)
+    fixed = "fixed-top" if layout.navbar_fixed else ""
+    return " ".join([
+        fixed,
+        layout.navbar_collapse_mode,
+        layout.navbar_color_scheme,
+        layout.navbar_format,
+        layout.navbar_class
+    ])
+
+
 @register.simple_tag
 def get_navbars():
     return Navbar.objects.all()


### PR DESCRIPTION
Should mostly fix issue #209

* Removing newlines in template tags when rendering them inside html attributes;
* convert tabs to spaces in html files;
* cleanup whitespace in html where appropriate