### PR TITLE
Compatibility with wagtail_modeltranslation

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -52,6 +52,7 @@ from wagtail.contrib.forms.forms import WagtailAdminFormPageForm
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.contrib.forms.models import FormSubmission
 from wagtail.search import index
+from wagtail.utils.decorators import cached_classmethod
 from wagtailcache.cache import WagtailCacheMixin
 
 from coderedcms import schema, utils
@@ -472,7 +473,7 @@ class CoderedPage(WagtailCacheMixin, Page, metaclass=CoderedPageMeta):
             self.index_order_by = self.index_order_by_default
             self.index_show_subpages = self.index_show_subpages_default
 
-    @classmethod
+    @cached_classmethod
     def get_edit_handler(cls):
         """
         Override to "lazy load" the panels overriden by subclasses.

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -1,0 +1,4 @@
+How-Tos
+=======
+
+Here you can find a collection of guides, some of which will let you achieve in CoderedCMS those customisations that users would expect to perform on Wagtail itself.

--- a/docs/how_to/translation.rst
+++ b/docs/how_to/translation.rst
@@ -1,0 +1,28 @@
+Translation
+===========
+
+Static content
+----------------------
+
+Due to CoderedCMS being heavily based on Wagtail, PO (Portable Objects) files translation follows Django's ``i18n`` pattern system. You are therefore encouraged to read Wagtail's official `documentation <http://docs.wagtail.io/en/latest/advanced_topics/i18n/>`_ on the topic.
+
+Models
+------
+
+Translation of model fields can be most efficiently and safely achieved via the well-known `Wagtail Model Translation <https://github.com/infoportugal/wagtail-modeltranslation>`_ package.
+
+Please note that, due to CoderedCMS' specific architecture, some fields are not exposed to the translation package by default, but it is required to do so inside ``models.py``.
+
+See below how that would be done for the ``body`` field for a specific ``MyPageModel``:
+
+.. code-block:: python
+
+    class MyPageModel(ParentModel):
+        body_content_panels = []
+        content_panels = ParentModel.content_panels + [
+            StreamFieldPanel('body'),
+        ]
+
+Admin panel
+-----------
+As explained in the Wagtail's official `documentation <http://docs.wagtail.io/en/latest/advanced_topics/i18n/>`_, you can easily enable a default language in the administration panel. You are encouraged to contribute to the project with translations.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,5 +27,6 @@ Contents
 
    getting_started/index
    features/index
+   how-to/index
    contributing/index
    releases/index


### PR DESCRIPTION
I haven't included the `coderedcms/project_template/basic/website/models.py` in the PR, but have a look at its content, specifically at the panel overriding required to actually show the "body" `content_panel`. I added it for each relevant back office page model's creation / edit view.

Please note that users wanting to install `wagtail-modeltranslation` with CoderedCMS wouldn't find instructions anywhere about the code below.

How would you like to proceed about this? 

```
"""
Createable pages used in CodeRed CMS.
"""
from modelcluster.fields import ParentalKey
from coderedcms.forms import CoderedFormField
from coderedcms.models import (
    CoderedArticlePage,
    CoderedArticleIndexPage,
    CoderedEmail,
    CoderedFormPage,
    CoderedWebPage
)


class ArticlePage(CoderedArticlePage):
    """
    Article, suitable for news or blog content.
    """
    class Meta:
        verbose_name = 'Article'
        ordering = ['-first_published_at', ]

    # Only allow this page to be created beneath an ArticleIndexPage.
    parent_page_types = ['website.ArticleIndexPage']

    template = 'coderedcms/pages/article_page.html'
    amp_template = 'coderedcms/pages/article_page.amp.html'
    search_template = 'coderedcms/pages/article_page.search.html'

    body_content_panels = []

    content_panels = CoderedArticlePage.content_panels + [
        StreamFieldPanel('body'),
    ]

class ArticleIndexPage(CoderedArticleIndexPage):
    """
    Shows a list of article sub-pages.
    """
    class Meta:
        verbose_name = 'Article Landing Page'

    # Override to specify custom index ordering choice/default.
    index_query_pagemodel = 'website.ArticlePage'

    # Only allow ArticlePages beneath this page.
    subpage_types = ['website.ArticlePage']

    template = 'coderedcms/pages/article_index_page.html'

    body_content_panels = []

    content_panels = CoderedArticleIndexPage.content_panels + [
        StreamFieldPanel('body'),
    ]

class FormPage(CoderedFormPage):
    """
    A page with an html <form>.
    """
    class Meta:
        verbose_name = 'Form'

    template = 'coderedcms/pages/form_page.html'

    body_content_panels = []

    content_panels = CoderedFormPage.content_panels + [
        StreamFieldPanel('body'),
    ]

class FormPageField(CoderedFormField):
    """
    A field that links to a FormPage.
    """
    class Meta:
        ordering = ['sort_order']

    page = ParentalKey('FormPage', related_name='form_fields')


class FormConfirmEmail(CoderedEmail):
    """
    Sends a confirmation email after submitting a FormPage.
    """
    page = ParentalKey('FormPage', related_name='confirmation_emails')


class WebPage(CoderedWebPage):
    """
    General use page with featureful streamfield and SEO attributes.
    Template renders all Navbar and Footer snippets in existance.
    """
    class Meta:
        verbose_name = 'Web Page'

    template = 'coderedcms/pages/web_page.html'

    body_content_panels = []

    content_panels = CoderedWebPage.content_panels + [
        StreamFieldPanel('body'),
    ]
```