### PR TITLE
Adding honeypot to page preview block (form)

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/pagepreview_form.html
+++ b/coderedcms/templates/coderedcms/blocks/pagepreview_form.html
@@ -9,6 +9,13 @@
     <form class='{{ page.form_css_class }}' id='{{ page.form_id }}' action="{% pageurl page %}" method="POST" {% if form|is_file_form %}enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         {% bootstrap_form form layout='horizontal' %}
+
+        {% block captcha %}
+            {% if page.spam_protection %}
+                {% include 'coderedcms/includes/form_honeypot.html' %}
+            {% endif %}
+        {% endblock %}
+
         <div class="form-group mt-5 row">
             <div class="{{'horizontal_label_class'|bootstrap_settings}}"></div>
             <div class="{{'horizontal_field_class'|bootstrap_settings}}">


### PR DESCRIPTION
Found one bug while testing, the page preview block is missing the honeypot when showing a form preview.