### PR TITLE
Fix pipeline code coverage comparison

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,17 +109,17 @@ stages:
         project: '$(System.TeamProjectId)'
         pipeline: '$(System.DefinitionId)'
 
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download code coverage from latest master build'
-      inputs:
-        source: 'specific'
-        path: '$(Agent.WorkFolder)/previous-artifacts'
-        project: '$(System.TeamProjectId)'
-        pipeline: '$(System.DefinitionId)'
-        runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
+    # - task: DownloadPipelineArtifact@2
+    #   displayName: 'Download code coverage from latest master build'
+    #   inputs:
+    #     source: 'specific'
+    #     path: '$(Agent.WorkFolder)/previous-artifacts'
+    #     project: '$(System.TeamProjectId)'
+    #     pipeline: '$(System.DefinitionId)'
+    #     runVersion: 'latestFromBranch'
+    #     runBranch: 'refs/heads/master'
 
-    - pwsh: ./ci/compare-artifacts.ps1 -wd $Env:WorkDir
+    - pwsh: ./ci/compare-artifacts.ps1 -wd $Env:WorkDir -org coderedcorp -project coderedcms
       displayName: 'CR-QC: Compare code coverage'
       env:
         WorkDir: $(Agent.WorkFolder)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,17 +109,7 @@ stages:
         project: '$(System.TeamProjectId)'
         pipeline: '$(System.DefinitionId)'
 
-    # - task: DownloadPipelineArtifact@2
-    #   displayName: 'Download code coverage from latest master build'
-    #   inputs:
-    #     source: 'specific'
-    #     path: '$(Agent.WorkFolder)/previous-artifacts'
-    #     project: '$(System.TeamProjectId)'
-    #     pipeline: '$(System.DefinitionId)'
-    #     runVersion: 'latestFromBranch'
-    #     runBranch: 'refs/heads/master'
-
-    - pwsh: ./ci/compare-artifacts.ps1 -wd $Env:WorkDir -org coderedcorp -project coderedcms
+    - pwsh: ./ci/compare-codecov.ps1 -wd $Env:WorkDir
       displayName: 'CR-QC: Compare code coverage'
       env:
         WorkDir: $(Agent.WorkFolder)

--- a/ci/compare-artifacts.ps1
+++ b/ci/compare-artifacts.ps1
@@ -8,23 +8,39 @@ Used by Azure Pipelines to compare code coverage reports between master and curr
 The working directory in which to find downloaded artifacts.
 #>
 
-param([string]$wd)
+param(
+    [string]$wd,
+    [Parameter(Mandatory = $true)] [string] $org,
+    [Parameter(Mandatory = $true)] [string] $project
+)
+
+# Get latest coverage from master.
+$ApiBase = "https://dev.azure.com/$org/$project"
+$masterBuildJson = (Invoke-WebRequest "$ApiBase/_apis/build/builds?branchName=refs/heads/master&api-version=5.1").Content | ConvertFrom-Json
+$masterLatestId = $masterBuildJson.value[0].id
+$masterCoverageJson = (Invoke-WebRequest "$ApiBase/_apis/test/codecoverage?buildId=$masterLatestId&api-version=5.1-preview.1").Content | ConvertFrom-Json
+foreach ($cov in $masterCoverageJson.coverageData.coverageStats) {
+    if ($cov.label -eq "Lines") {
+        $masterlinerate = [math]::Round(($cov.covered / $cov.total) * 100, 2)
+    }
+}
 
 if (Test-Path -Path "$wd/current-artifacts/Code Coverage Report_*/summary*/coverage.xml") {
     [xml]$BranchXML = Get-Content "$wd/current-artifacts/Code Coverage Report_*/summary*/coverage.xml"
-} else {
+}
+else {
     Write-Host "No code coverage from this build. Is pytest configured to output code coverage? Exiting pipeline." -ForegroundColor Red
     exit 1
 }
 
-if (Test-Path -Path "$wd/previous-artifacts/Code Coverage Report_*/summary*/coverage.xml") {
-    [xml]$MasterXML = Get-Content "$wd/previous-artifacts/Code Coverage Report_*/summary*/coverage.xml"
-} else {
-    Write-Host "No code coverage from previous build. Exiting pipeline." -ForegroundColor Red
-    exit 2
-}
+#if (Test-Path -Path "$wd/previous-artifacts/Code Coverage Report_*/summary*/coverage.xml") {
+#    [xml]$MasterXML = Get-Content "$wd/previous-artifacts/Code Coverage Report_*/summary*/coverage.xml"
+#} else {
+#    Write-Host "No code coverage from previous build. Exiting pipeline." -ForegroundColor Red
+#    exit 2
+#}
 
-$masterlinerate = [math]::Round([decimal]$MasterXML.coverage.'line-rate' * 100, 2)
+#$masterlinerate = [math]::Round([decimal]$MasterXML.coverage.'line-rate' * 100, 2)
 $branchlinerate = [math]::Round([decimal]$BranchXML.coverage.'line-rate' * 100, 2)
 
 Write-Output "Master line coverage rate:  $masterlinerate%"
@@ -32,17 +48,20 @@ Write-Output "Branch line coverage rate:  $branchlinerate%"
 
 if ($masterlinerate -eq 0) {
     $change = "Infinite"
-} else {
+}
+else {
     $change = [math]::Abs($branchlinerate - $masterlinerate)
 }
 
 if ($branchlinerate -gt $masterlinerate) {
     Write-Host "Coverage increased by $change% 😀" -ForegroundColor Green
     exit 0
-} elseif ($branchlinerate -eq $masterlinerate) {
+}
+elseif ($branchlinerate -eq $masterlinerate) {
     Write-Host "Coverage has not changed." -ForegroundColor Green
     exit 0
-} else {
+}
+else {
     Write-Host "Coverage decreased by $change% 😭" -ForegroundColor Red
     exit 4
 }

--- a/ci/compare-codecov.ps1
+++ b/ci/compare-codecov.ps1
@@ -2,14 +2,14 @@
 
 <#
 .SYNOPSIS
-Used by Azure Pipelines to compare code coverage reports between master and current branch.
+Compares code coverage percent of local coverage.xml file to master branch (Azure Pipeline API).
 
 .PARAMETER wd
 The working directory in which to search for current coverage.xml.
 #>
 
 param(
-    [string] $wd,
+    [string] $wd = (Get-Item (Split-Path $PSCommandPath -Parent)).Parent,
     [string] $org = "coderedcorp",
     [string] $project = "coderedcms"
 )

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -130,7 +130,14 @@ code coverage percentage in the console:
     $ ./ci/run-tests.ps1
 
 Detailed test coverage reports are now available by opening ``htmlcov/index.html``
-in your browser (which is ignored by version control)
+in your browser (which is ignored by version control).
+
+To compare your current code coverage against the code coverage of the master
+branch (based on latest Azure Pipeline build from master) run:
+
+.. code-block:: console
+
+    $ ./ci/compare-codecov.ps1
 
 
 Adding New Tests


### PR DESCRIPTION
[Found an API](https://docs.microsoft.com/en-us/rest/api/azure/devops/test/Code%20Coverage/Get%20Build%20Code%20Coverage?view=azure-devops-rest-5.1) that somehow magically pulls the code coverage. Seems to work better than trying to download the artifact from the master branch. This should work better on external pull requests (See https://github.com/MicrosoftDocs/vsts-docs/issues/5588). Plus we have the advantage of being able to run it locally now to compare code coverage before committing.

Updated contributor guide.