### PR TITLE
fixing custom_css_class and custom_css_id reference typo

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/google_map.html
+++ b/coderedcms/templates/coderedcms/blocks/google_map.html
@@ -1,5 +1,5 @@
 <div class="embed-responsive embed-responsive-16by9 {{self.settings.custom_css_clas}}"
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
 	{% if self.place_id %}
 		<iframe class="embed-responsive-item" width="100%" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=place_id:{{ self.place_id }}&zoom={{ self.map_zoom_level }}&key={{ settings.GoogleApiSettings.google_maps_api_key}}" title="{{self.map_title}}" allowfullscreen></iframe>
 	{% else %}

--- a/coderedcms/templates/coderedcms/blocks/h1_block.html
+++ b/coderedcms/templates/coderedcms/blocks/h1_block.html
@@ -1,4 +1,4 @@
-<h1 {% if self.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+<h1 {% if self.settings.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
+{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
     {{ self.text }}
 </h1>

--- a/coderedcms/templates/coderedcms/blocks/h2_block.html
+++ b/coderedcms/templates/coderedcms/blocks/h2_block.html
@@ -1,4 +1,4 @@
-<h2 {% if self.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+<h2 {% if self.settings.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
+{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
     {{ self.text }}
 </h2>

--- a/coderedcms/templates/coderedcms/blocks/h3_block.html
+++ b/coderedcms/templates/coderedcms/blocks/h3_block.html
@@ -1,4 +1,4 @@
-<h3 {% if self.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+<h3 {% if self.settings.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
+{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
     {{ self.text }}
 </h3>

--- a/coderedcms/templates/coderedcms/blocks/hero_block.html
+++ b/coderedcms/templates/coderedcms/blocks/hero_block.html
@@ -7,7 +7,7 @@
 {% image self.background_image max-2000x2000 as background_image %}
 <div class="hero-bg {% if self.is_parallax %}parallax{% endif %} {% if self.tile_image %}tile{% endif %} {{self.settings.custom_css_class}}"
     style="{% if self.background_color %}background-color:{{self.background_color}};{% endif %}{% if background_image %}background-image:url({{background_image.url}});{% endif %}"
-    {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+    {% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
     <div class="hero-fg" style="{% if self.foreground_color %}color:{{self.foreground_color}};{% endif %}">
         {% include_block self.content %}
     </div>

--- a/coderedcms/templates/coderedcms/blocks/image_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_block.html
@@ -6,15 +6,15 @@
 
 <amp-img src="{{self_image.url}}"
 layout="responsive" width="{{self_image.width}}" height="{{self_image.height}}"
-class="{{self.custom_css_class}}"
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}
+class="{{self.settings.custom_css_class}}"
+{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}
 alt="{{self_image.image.title}}"></amp-img>
 
 {% else %}
 
 <img src="{{self_image.url}}"
 class="w-100 {{self.settings.custom_css_class}}"
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}
+{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}
 alt="{{self_image.image.title}}" />
 
 {% endif %}

--- a/coderedcms/templates/coderedcms/blocks/image_gallery_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_gallery_block.html
@@ -4,7 +4,7 @@
 {% generate_random_id as modal_id %}
 
 <section class="{{self.settings.custom_css_class}}"
-    {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+    {% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
 
 <div class="row">
 {% for picture in pictures %}

--- a/coderedcms/templates/coderedcms/blocks/table_block.html
+++ b/coderedcms/templates/coderedcms/blocks/table_block.html
@@ -1,4 +1,4 @@
-<table class="table {{ self.settings.custom_css_class }}" {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+<table class="table {{ self.settings.custom_css_class }}" {% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
     {% if self.table.first_row_is_table_header %}
         <thead>
             <tr>


### PR DESCRIPTION
Correct typos on custom_css_class and custom_css_id reference in the block templates.