### PR TITLE
Corrects attributes set for custom CSS classes or custom IDs.

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/card_block.html
+++ b/coderedcms/templates/coderedcms/blocks/card_block.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="card mb-3 {{self.settings.custom_css_class}}"
-{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     {% if self.image %}
     {% image self.image fill-900x600 as card_img %}
     <img class="card-img-top w-100" src="{{card_img.url}}" alt="{{card_img.title}}">

--- a/coderedcms/templates/coderedcms/blocks/card_blurb.html
+++ b/coderedcms/templates/coderedcms/blocks/card_blurb.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="card mb-3 border-0 bg-transparent text-center {{self.settings.custom_css_class}}"
-{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     {% if self.image %}
     {% image self.image fill-150x150 as card_img %}
     <img class="rounded-circle w-25 mx-auto" src="{{card_img.url}}" alt="{{card_img.title}}">

--- a/coderedcms/templates/coderedcms/blocks/card_foot.html
+++ b/coderedcms/templates/coderedcms/blocks/card_foot.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="card mb-3 {{self.settings.custom_css_class}}"
-{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     {% if self.image %}
     {% image self.image fill-900x600 as card_img %}
     <img class="card-img-top w-100" src="{{card_img.url}}" alt="{{card_img.title}}">

--- a/coderedcms/templates/coderedcms/blocks/card_head.html
+++ b/coderedcms/templates/coderedcms/blocks/card_head.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="card mb-3 {{self.settings.custom_css_class}}"
-{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     {% if self.title %}<h5 class="card-header">{{self.title}}</h5>{% endif %}
     {% if self.image %}
     {% image self.image fill-900x600 as card_img %}

--- a/coderedcms/templates/coderedcms/blocks/card_head_foot.html
+++ b/coderedcms/templates/coderedcms/blocks/card_head_foot.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="card mb-3 {{self.settings.custom_css_class}}"
-{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     {% if self.title %}<h5 class="card-header">{{self.title}}</h5>{% endif %}
     {% if self.image %}
     {% image self.image fill-900x600 as card_img %}

--- a/coderedcms/templates/coderedcms/blocks/card_img.html
+++ b/coderedcms/templates/coderedcms/blocks/card_img.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="card mb-3 bg-dark text-white {{self.settings.custom_css_class}}"
-{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}
 {% if self.image %}
 {% image self.image fill-1000x1000 as card_img %}
 style="background-image:url('{{card_img.url}}');"

--- a/coderedcms/templates/coderedcms/blocks/google_map.html
+++ b/coderedcms/templates/coderedcms/blocks/google_map.html
@@ -1,5 +1,5 @@
 <div class="embed-responsive embed-responsive-16by9 {{self.settings.custom_css_clas}}"
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
 	{% if self.place_id %}
 		<iframe class="embed-responsive-item" width="100%" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=place_id:{{ self.place_id }}&zoom={{ self.map_zoom_level }}&key={{ settings.GoogleApiSettings.google_maps_api_key}}" title="{{self.map_title}}" allowfullscreen></iframe>
 	{% else %}

--- a/coderedcms/templates/coderedcms/blocks/h1_block.html
+++ b/coderedcms/templates/coderedcms/blocks/h1_block.html
@@ -1,4 +1,4 @@
-<h1 {% if self.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+<h1 {% if self.settings.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     {{ self.text }}
 </h1>

--- a/coderedcms/templates/coderedcms/blocks/h2_block.html
+++ b/coderedcms/templates/coderedcms/blocks/h2_block.html
@@ -1,4 +1,4 @@
-<h2 {% if self.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+<h2 {% if self.settings.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     {{ self.text }}
 </h2>

--- a/coderedcms/templates/coderedcms/blocks/h3_block.html
+++ b/coderedcms/templates/coderedcms/blocks/h3_block.html
@@ -1,4 +1,4 @@
-<h3 {% if self.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+<h3 {% if self.settings.custom_css_class %}class="{{self.settings.custom_css_class}}"{% endif %}
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     {{ self.text }}
 </h3>

--- a/coderedcms/templates/coderedcms/blocks/hero_block.html
+++ b/coderedcms/templates/coderedcms/blocks/hero_block.html
@@ -7,7 +7,7 @@
 {% image self.background_image max-2000x2000 as background_image %}
 <div class="hero-bg {% if self.is_parallax %}parallax{% endif %} {% if self.tile_image %}tile{% endif %} {{self.settings.custom_css_class}}"
     style="{% if self.background_color %}background-color:{{self.background_color}};{% endif %}{% if background_image %}background-image:url({{background_image.url}});{% endif %}"
-    {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+    {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     <div class="hero-fg" style="{% if self.foreground_color %}color:{{self.foreground_color}};{% endif %}">
         {% include_block self.content %}
     </div>

--- a/coderedcms/templates/coderedcms/blocks/image_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_block.html
@@ -6,15 +6,15 @@
 
 <amp-img src="{{self_image.url}}"
 layout="responsive" width="{{self_image.width}}" height="{{self_image.height}}"
-class="{{self.custom_css_class}}"
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}
+class="{{self.settings.custom_css_class}}"
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}
 alt="{{self_image.image.title}}"></amp-img>
 
 {% else %}
 
 <img src="{{self_image.url}}"
 class="w-100 {{self.settings.custom_css_class}}"
-{% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}
 alt="{{self_image.image.title}}" />
 
 {% endif %}

--- a/coderedcms/templates/coderedcms/blocks/image_gallery_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_gallery_block.html
@@ -4,7 +4,7 @@
 {% generate_random_id as modal_id %}
 
 <section class="{{self.settings.custom_css_class}}"
-    {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+    {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
 
 <div class="row">
 {% for picture in pictures %}

--- a/coderedcms/templates/coderedcms/blocks/pagepreview_card.html
+++ b/coderedcms/templates/coderedcms/blocks/pagepreview_card.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="card mb-3 {{self.settings.custom_css_class}}"
-{% if self.settings.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
 {% with page=self.page.specific %}
     {% if page.cover_image %}
     {% image page.cover_image fill-900x600 as card_img %}

--- a/coderedcms/templates/coderedcms/blocks/table_block.html
+++ b/coderedcms/templates/coderedcms/blocks/table_block.html
@@ -1,4 +1,4 @@
-<table class="table {{ self.settings.custom_css_class }}" {% if self.custom_css_id %}id="{{self.settings.custom_css_id}}"{% endif %}>
+<table class="table {{ self.settings.custom_css_class }}" {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
     {% if self.table.first_row_is_table_header %}
         <thead>
             <tr>


### PR DESCRIPTION
#### Description of change
Corrects attributes set for custom CSS classes or custom IDs.

As promised per https://github.com/coderedcorp/coderedcms/issues/275 , unifies the custom CSS and ID attributes. Pulls from `self.settings` consistently, and also uses `custom_id` rather than `custom_css_id`.