### PR TITLE
Include Custom CSS and ID in reusable content blocks. See Issue #275,…

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/reusable_content_block.html
+++ b/coderedcms/templates/coderedcms/blocks/reusable_content_block.html
@@ -1,2 +1,5 @@
 {% load wagtailcore_tags %}
-{% include_block self.content.content %}
+
+<div {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %} class="block-html {{ self.settings.custom_css_class }}">
+  {% include_block self.content %}
+</div>


### PR DESCRIPTION
… PR #293

Thank you for contributing! Please follow the guidelines below to submit your
pull request. Additional details are available in our
[Contributor Guide](https://docs.coderedcorp.com/cms/stable/contributing/index.html).

#### Description of change
This is a partial fix to the issue of spotty custom CSS and ID rendering referred to in #275. 
#293 by @bahoo is also a partial fix.

#### Documentation
N/A

#### Tests
To test: Create a snippet|reusable-content, and give it css and id. Create a Responsive Grid Row and add a Column. In the column include the reusable content. In the HTML you'll see the id and CSS for your snippet.
