### PR TITLE
render html snippet contents rather than the snippet name.

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/reusable_content_block.html
+++ b/coderedcms/templates/coderedcms/blocks/reusable_content_block.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags %}
 
 <div {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %} class="block-html {{ self.settings.custom_css_class }}">
-  {% include_block self.content %}
+  {% include_block self.content.content %}
 </div>


### PR DESCRIPTION
#### Description of change
My commit yesterday, #de36594 - a partial fix to #275, fixed the custom CSS and ID, but introduced a bug where the snippet name was rendered, not the content.  
This fixes that.
My apologies.

#### Tests
Create and include an HTML reusable content, setting a CSS, an ID, and a piece of content. Ensure that all three attributes are rendered to HTML.