### PR TITLE
Upgrade to Wagtail 2.9

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE *.md *.rst *.txt
+include LICENSE README.md
 graft coderedcms
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ stages:
         versionSpec: '$(PYTHON_VERSION)'
         architecture: 'x64'
 
-    - script: python -m pip install -e ./[ci]
+    - script: python -m pip install -r requirements-ci.txt
       displayName: 'CR-QC: Install coderedcms from local repo'
 
     - script: coderedcms start testproject
@@ -88,7 +88,7 @@ stages:
         versionSpec: '3.8'
         architecture: 'x64'
 
-    - script: python -m pip install -e ./[ci]
+    - script: python -m pip install -r requirements-ci.txt
       displayName: 'CR-QC: Install coderedcms from local repo'
 
     - script: coderedcms start testproject
@@ -128,7 +128,7 @@ stages:
         versionSpec: '3.8'
         architecture: 'x64'
 
-    - script: python -m pip install -e ./[ci]
+    - script: python -m pip install -r requirements-ci.txt
       displayName: 'CR-QC: Install coderedcms from local repo'
 
     - pwsh: ./ci/make-docs.ps1

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -523,7 +523,7 @@ class CoderedPage(WagtailCacheMixin, Page, metaclass=CoderedPageMeta):
         Override parent to serve different templates based on querystring.
         """
         if 'amp' in request.GET and hasattr(self, 'amp_template'):
-            seo_settings = SeoSettings.for_site(request.site)
+            seo_settings = SeoSettings.for_request(request)
             if seo_settings.amp_pages:
                 if request.is_ajax():
                     return self.ajax_template or self.amp_template
@@ -1217,7 +1217,7 @@ class CoderedFormMixin(models.Model):
                     template_from_email = Template(email.from_address)
                     message_args['from_email'] = template_from_email.render(context)
                 else:
-                    genemail = GeneralSettings.for_site(request.site).from_email_address
+                    genemail = GeneralSettings.for_request(request).from_email_address
                     if genemail:
                         message_args['from_email'] = genemail
                 # Reply-to
@@ -1277,7 +1277,7 @@ class CoderedFormMixin(models.Model):
             message_args['subject'] = self.subject
         else:
             message_args['subject'] = self.title
-        genemail = GeneralSettings.for_site(request.site).from_email_address
+        genemail = GeneralSettings.for_request(request).from_email_address
         if genemail:
             message_args['from_email'] = genemail
         if self.reply_address:

--- a/coderedcms/project_template/basic/project_name/settings/base.py
+++ b/coderedcms/project_template/basic/project_name/settings/base.py
@@ -82,7 +82,6 @@ MIDDLEWARE = [
     # 'django.middleware.common.BrokenLinkEmailsMiddleware',
 
     # CMS functionality
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 
     # Fetch from cache. Must be LAST.

--- a/coderedcms/project_template/sass/project_name/settings/base.py
+++ b/coderedcms/project_template/sass/project_name/settings/base.py
@@ -81,7 +81,6 @@ MIDDLEWARE = [
     #'django.middleware.common.BrokenLinkEmailsMiddleware',
 
     # CMS functionality
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 
     # Fetch from cache. Must be LAST.

--- a/coderedcms/static/coderedcms/css/codered-admin.css
+++ b/coderedcms/static/coderedcms/css/codered-admin.css
@@ -203,9 +203,9 @@ input[type='checkbox']::before, input[type='radio']::before {
 
 .logo {
     margin: 0 auto;
-    padding: 15px;
+    padding: 1em;
 }
-.logo img {
+.logo img.logo-custom {
     width:auto;
     height:auto;
     max-height:80px;
@@ -235,11 +235,6 @@ input[type='checkbox']::before, input[type='radio']::before {
 .submenu-active * {
     box-sizing: border-box;
 }
-.nav-submenu .footer {
-    color:#666;
-    position:relative;
-    width:100%;
-}
 
 @media screen and (min-width:50em) {
     li.submenu-active .nav-submenu {
@@ -248,9 +243,6 @@ input[type='checkbox']::before, input[type='radio']::before {
     li.submenu-active .nav-submenu a {
         padding-left:1em;
         width:100%;
-    }
-    .nav-submenu {
-        display:none;
     }
     .nav-submenu h2, .nav-submenu ul {
         width:100%;
@@ -268,9 +260,6 @@ input[type='checkbox']::before, input[type='radio']::before {
     .footer .avatar {
         width: 40px;
         height: 40px;
-    }
-    .submenu-active .nav-submenu {
-        display:block;
     }
 }
 
@@ -290,20 +279,20 @@ input[type='checkbox']::before, input[type='radio']::before {
 .power-by {
     background-color:#1a1a1a;
     border-top:1px solid #333;
-    font-size:12px;
+    font-size:10px;
     text-align: center;
 }
 
 .power-by a {
     color:#fff;
-    padding: 5px;
+    padding: 2px;
 }
 .power-by a:hover {
     background-color:#f00;
 }
 
 .power-by img {
-    width:85px;
+    width:75px;
     height:auto;
     padding-left:2px;
 }

--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -2,6 +2,7 @@
 {% get_settings %}
 {% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
+{% wagtail_site as site %}
 
 
 <!doctype html>
@@ -23,7 +24,7 @@
 
         {# Pass in CMS variables to JavaScript #}
         <script>
-            cr_site_url = "{{request.site.root_url}}";
+            cr_site_url = "{{site.root_url}}";
             cr_external_new_tab = {{settings.coderedcms.GeneralSettings.external_new_tab|yesno:"true,false"}};
         </script>
 
@@ -33,7 +34,7 @@
 
         {# HTML SEO #}
         {% block html_seo_base %}
-        <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% if not self.seo_title %} - {{request.site.site_name}}{% endif %}{% endblock %}</title>
+        <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% if not self.seo_title %} - {{site.site_name}}{% endif %}{% endblock %}</title>
         <meta name="description" content="{% block description %}{% if self.search_description %}{{ self.search_description }}{% endif %}{% endblock %}" />
         <link rel="canonical" href="{% block canonical %}{{self.get_full_url}}{% endblock %}">
         {% endblock %}

--- a/coderedcms/templates/coderedcms/snippets/navbar.html
+++ b/coderedcms/templates/coderedcms/snippets/navbar.html
@@ -1,4 +1,5 @@
 {% load wagtailcore_tags wagtailsettings_tags wagtailimages_tags coderedcms_tags i18n %}
+{% wagtail_site as site %}
 
 {% if not settings.coderedcms.LayoutSettings.navbar_wrapper_fluid %}
 <div class="container">
@@ -13,9 +14,9 @@
     <a class="navbar-brand" href="/">
       {% if settings.coderedcms.LayoutSettings.logo %}
         {% image settings.coderedcms.LayoutSettings.logo original as logo %}
-        <img src="{{logo.url}}" alt="{{request.site.site_name}}" />
+        <img src="{{logo.url}}" alt="{{site.site_name}}" />
       {% else %}
-        {{request.site.site_name}}
+        {{site.site_name}}
       {% endif %}
     </a>
 

--- a/coderedcms/templates/wagtailadmin/base.html
+++ b/coderedcms/templates/wagtailadmin/base.html
@@ -4,8 +4,8 @@
 
 {% block branding_logo %}
     {% if settings.coderedcms.LayoutSettings.logo %}
-        {% image settings.coderedcms.LayoutSettings.logo max-150x100 as logo_image %}
-        <img src="{{ logo_image.url }}" alt="Dashboard"/>
+        {% image settings.coderedcms.LayoutSettings.logo max-300x300 as logo_image %}
+        <img src="{{ logo_image.url }}" class="logo-custom" alt="Dashboard"/>
     {% else %}
         {{block.super}}
     {% endif %}

--- a/coderedcms/templates/wagtailadmin/shared/menu_settings_menu_item.html
+++ b/coderedcms/templates/wagtailadmin/shared/menu_settings_menu_item.html
@@ -1,6 +1,0 @@
-{% extends "wagtailadmin/shared/menu_settings_menu_item.html" %}
-{% load coderedcms_tags %}
-
-{% block menu_footer %}
-    <li class="footer"><div class="menu-item"><p class="wagtail-version">CodeRed&nbsp;CMS v&nbsp;{% coderedcms_version %}</p></div></li>
-{% endblock %}

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -8,7 +8,7 @@ from django import template
 from django.conf import settings
 from django.forms import ClearableFileInput
 from django.utils.html import mark_safe
-from wagtail.core.models import Collection
+from wagtail.core.models import Collection, Site
 from wagtail.core.rich_text import RichText
 from wagtail.core.templatetags.wagtailcore_tags import richtext
 from wagtail.images.models import Image
@@ -54,16 +54,18 @@ def og_image(context, page):
     if protocol.match(settings.MEDIA_URL):
         base_url = ''
     else:
-        base_url = context['request'].site.root_url
+        base_url = Site.find_for_request(context['request']).root_url
 
     if page:
         if page.og_image:
             return base_url + page.og_image.get_rendition('original').url
         elif page.cover_image:
             return base_url + page.cover_image.get_rendition('original').url
-    if LayoutSettings.for_site(context['request'].site).logo:
-        layout_settings = LayoutSettings.for_site(context['request'].site)
+
+    layout_settings = LayoutSettings.for_request(context['request'])
+    if layout_settings.logo:
         return base_url + layout_settings.logo.get_rendition('original').url
+
     return None
 
 
@@ -94,7 +96,7 @@ def get_pictures(collection_id):
 
 @register.simple_tag(takes_context=True)
 def get_navbar_css(context):
-    layout = LayoutSettings.for_site(context['request'].site)
+    layout = LayoutSettings.for_request(context['request'])
     fixed = "fixed-top" if layout.navbar_fixed else ""
     return " ".join([
         fixed,

--- a/coderedcms/views.py
+++ b/coderedcms/views.py
@@ -81,8 +81,7 @@ def search(request):
 
         # paginate results
         if results:
-            paginator = Paginator(results, GeneralSettings.for_site(
-                request.site).search_num_results)
+            paginator = Paginator(results, GeneralSettings.for_request(request).search_num_results)
             page = request.GET.get('p', 1)
             try:
                 results_paginated = paginator.page(page)
@@ -124,7 +123,7 @@ def serve_protected_file(request, path):
 
 
 def favicon(request):
-    icon = LayoutSettings.for_site(request.site).favicon
+    icon = LayoutSettings.for_request(request).favicon
     if icon:
         return HttpResponsePermanentRedirect(icon.get_rendition('original').url)
     raise Http404()

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -8,11 +8,10 @@ Developing CodeRed CMS
 To create a test project locally:
 
 #. Clone the code from https://github.com/coderedcorp/coderedcms.
-#. Run ``pip install -e ./[dev]`` from the root coderedcms directory.
-   The -e flag makes the install editable, which is relevant when running
-   ``makemigrations`` in test project to actually generate the migration files
-   in the coderedcms pip package. The ``[dev]`` installs extras such as sphinx
-   for generating docs.
+#. Run ``pip install -r requirements-dev.txt`` from the root coderedcms
+   directory. This will install development tools, and also make the install
+   editable, which is relevant when running ``makemigrations`` in test project
+   to actually generate the migration files in the coderedcms pip package.
 #. Follow the steps in :doc:`/getting_started/install`. Use ``testproject`` for
    your project name to ensure it is ignored by git.
 #. When making model or block changes within coderedcms, run

--- a/docs/releases/v0.19.0.rst
+++ b/docs/releases/v0.19.0.rst
@@ -18,9 +18,12 @@ Upgrade considerations
 
 * For Wagtail 2.9 ``SiteMiddleware`` and ``request.site`` are deprecated.
   Custom code in your project should be updated as so:
+
   * In python, replace ``request.site`` with ``Site.find_for_request(request)``.
+
   * In Python, to load a site setting, replace
     ``Setting.for_site(request.site)`` with ``Setting.for_request(request)``.
+
   * In HTML templates, replace ``request.site`` with:
 
     ..code-block: html

--- a/docs/releases/v0.19.0.rst
+++ b/docs/releases/v0.19.0.rst
@@ -9,18 +9,39 @@ Bug fixes
 New features
 ------------
 
+* Upgraded to Wagtail 2.9
 * Upgraded to Bootstrap 4.5 and jQuery 3.5.1
 
 
 Upgrade considerations
 ----------------------
 
+* For Wagtail 2.9 ``SiteMiddleware`` and ``request.site`` are deprecated.
+  Custom code in your project should be updated as so:
+  * In python, replace ``request.site`` with ``Site.find_for_request(request)``.
+  * In Python, to load a site setting, replace
+    ``Setting.for_site(request.site)`` with ``Setting.for_request(request)``.
+  * In HTML templates, replace ``request.site`` with:
+
+    ..code-block: html
+
+      {% load wagtailcore_tags %}
+      {% wagtail_site as site %}
+
+      <p>Your site name is: {{site.site_name}}</p>
+
+  * Following these changes, you should then remove
+    ``wagtail.core.middleware.SiteMiddleware`` from the Django ``MIDDLEWARE``
+    (in ``settings/base.py``)
+
 * If you have overridden ``coderedcms/pages/base.html``, you may need to update
   references to ``jquery-3.4.1`` to ``jquery-3.5.1``.
+
 * If using SASS, you may need to update your ``custom.scss`` or
   ``_variables.scss`` files accordingly to support Bootstrap 4.5. Or you may
   continue using Bootstrap 4.3 by `downloading a copy of the Bootstrap 4.3
   sources <https://getbootstrap.com/docs/4.3/getting-started/download/>`_
   and changing the references in your ``custom.scss`` to use these files.
+
 * You may need to run ``python manage.py makemigrations website`` and
   ``python manage.py migrate`` after upgrading.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,8 @@
+# Install coderedcms from local directory.
+-e .
+
+# Requirements, in addition to coderedcms, needed for CI runner.
+flake8
+pytest-cov
+pytest-django
+sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+# Install coderedcms from local directory.
+-e .
+
+# Requirements, in addition to coderedcms, needed for development.
+flake8
+libsass
+pytest-cov
+pytest-django
+sphinx
+twine
+wheel

--- a/setup.py
+++ b/setup.py
@@ -43,35 +43,17 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],
     install_requires=[
-        'beautifulsoup4>=4.5.1,<4.6.1',  # should be the same as wagtail
+        'beautifulsoup4>=4.8,<4.9',  # should be the same as wagtail
         'django-eventtools==1.0.*',
-        'django-bootstrap4',
-        'Django>2.1,<3.1',              # should be the same as wagtail
-        'django-taggit<1.3',
-        'geocoder>=1.38.1,<2.0',
+        'django-bootstrap4==2.0.*',
+        'Django>2.1,<3.1',           # should be the same as wagtail
+        'geocoder==1.38.*',
         'icalendar==4.0.*',
-        'wagtail==2.8.*',
-        'wagtailfontawesome>=1.1.4,<2.0',
+        'wagtail==2.9.*',
+        'wagtailfontawesome>=1.2.*',
         'wagtail-cache==1.*',
         'wagtail-import-export>=0.2,<0.3'
     ],
-    extras_require={
-        "ci": [
-            "flake8",
-            "pytest-cov",
-            "pytest-django",
-            "sphinx"
-        ],
-        "dev": [
-            "flake8",
-            "libsass",
-            "pytest-cov",
-            "pytest-django",
-            "sphinx",
-            "twine",
-            "wheel",
-        ],
-    },
     entry_points="""
             [console_scripts]
             coderedcms=coderedcms.bin.coderedcms:main

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3 :: Only',
         'Framework :: Django',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Wagtail',
@@ -43,10 +42,10 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],
     install_requires=[
-        'beautifulsoup4>=4.8,<4.9',  # should be the same as wagtail
+        'beautifulsoup4>=4.8,<4.9',     # should be the same as wagtail
         'django-eventtools==1.0.*',
-        'django-bootstrap4==2.0.*',
-        'Django>2.1,<3.1',           # should be the same as wagtail
+        'django-bootstrap4>=1.0,<2.3',  # Version 2.0 only supports Python 3.6 and up.
+        'Django>2.1,<3.1',              # should be the same as wagtail
         'geocoder==1.38.*',
         'icalendar==4.0.*',
         'wagtail==2.9.*',


### PR DESCRIPTION
* Upgrade to Wagtail 2.9
* Remove deprecated use of `SiteMiddleware` and `request.site`.
* Pin/update/remove dependencies as needed.
* Move extras out of setup.py and into requirement files. This was not an appropriate use of the extras.

Fixes #330 and #324 
