### PR TITLE
Fix google map CSS class and API key in HTML templates

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/google_map.html
+++ b/coderedcms/templates/coderedcms/blocks/google_map.html
@@ -1,8 +1,8 @@
-<div class="embed-responsive embed-responsive-16by9 {{self.settings.custom_css_clas}}"
+<div class="embed-responsive embed-responsive-16by9 {{self.settings.custom_css_class}}"
 {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
-	{% if self.place_id %}
-		<iframe class="embed-responsive-item" width="100%" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=place_id:{{ self.place_id }}&zoom={{ self.map_zoom_level }}&key={{ settings.GoogleApiSettings.google_maps_api_key}}" title="{{self.map_title}}" allowfullscreen></iframe>
-	{% else %}
-		<iframe class="embed-responsive-item" width="100%" style="border:0" src="https://maps.google.com/maps?q={{ self.search|urlencode }}&output=embed" title="{{self.map_title}}" allowfullscreen></iframe>
-	{% endif %}
+  {% if self.place_id %}
+  <iframe class="embed-responsive-item" width="100%" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=place_id:{{ self.place_id }}&zoom={{ self.map_zoom_level }}&key={{ settings.coderedcms.GoogleApiSettings.google_maps_api_key}}" title="{{self.map_title}}" allowfullscreen></iframe>
+  {% else %}
+  <iframe class="embed-responsive-item" width="100%" style="border:0" src="https://maps.google.com/maps?q={{ self.search|urlencode }}&output=embed" title="{{self.map_title}}" allowfullscreen></iframe>
+  {% endif %}
 </div>

--- a/docs/releases/v0.19.0.rst
+++ b/docs/releases/v0.19.0.rst
@@ -8,6 +8,8 @@ Bug fixes
 * Support custom image models by correctly using  ``WAGTAILIMAGES_IMAGE_MODEL``
   versus hard-coding ``wagtailimages.Image``.
 
+* Fix custom CSS class and Google Maps API key in Google Map block.
+
 * ``coderedcms start`` now pins the version of CodeRed CMS in the generated
   ``requirements.txt`` file.
 


### PR DESCRIPTION
Fixes #220 

Tested manually and confirmed issue is fixed. This would be a great test for adding block unit tests.