### PR TITLE
Sending mails through other connection

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1252,9 +1252,7 @@ class CoderedFormMixin(models.Model):
                 message_args['to'] = template_to.render(context).split(',')
 
                 # Send email
-                message = EmailMessage(**message_args)
-                message.content_subtype = 'html'
-                message.send()
+                self.__send_mail(message_args)
 
         for fn in hooks.get_hooks('form_page_submit'):
             fn(instance=self, form_submission=form_submission)
@@ -1293,7 +1291,11 @@ class CoderedFormMixin(models.Model):
             message_args['reply_to'] = template_reply_to.render(context).split(',')
 
         # Send email
+        self.__send_mail(message_args)
+
+    def __send_mail(self, message_args):
         message = EmailMessage(**message_args)
+        message.content_subtype = "html"
         message.send()
 
     def render_landing_page(self, request, form_submission=None):

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1252,7 +1252,7 @@ class CoderedFormMixin(models.Model):
                 message_args['to'] = template_to.render(context).split(',')
 
                 # Send email
-                self.__send_mail(message_args)
+                self.__send_mail(request, message_args)
 
         for fn in hooks.get_hooks('form_page_submit'):
             fn(instance=self, form_submission=form_submission)
@@ -1291,9 +1291,9 @@ class CoderedFormMixin(models.Model):
             message_args['reply_to'] = template_reply_to.render(context).split(',')
 
         # Send email
-        self.__send_mail(message_args)
+        self.__send_mail(request, message_args)
 
-    def __send_mail(self, message_args):
+    def __send_mail(self, resuest, message_args):
         message = EmailMessage(**message_args)
         message.content_subtype = "html"
         message.send()

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1252,7 +1252,7 @@ class CoderedFormMixin(models.Model):
                 message_args['to'] = template_to.render(context).split(',')
 
                 # Send email
-                self.__send_mail(request, message_args)
+                self.send_mail(request, message_args, 'html')
 
         for fn in hooks.get_hooks('form_page_submit'):
             fn(instance=self, form_submission=form_submission)
@@ -1291,11 +1291,11 @@ class CoderedFormMixin(models.Model):
             message_args['reply_to'] = template_reply_to.render(context).split(',')
 
         # Send email
-        self.__send_mail(request, message_args)
+        self.send_mail(request, message_args)
 
-    def __send_mail(self, resuest, message_args):
+    def send_mail(self, resuest, message_args, content_subtype='text'):
         message = EmailMessage(**message_args)
-        message.content_subtype = "html"
+        message.content_subtype = content_subtype
         message.send()
 
     def render_landing_page(self, request, form_submission=None):


### PR DESCRIPTION
This PR allows sending mails through other connections than the default in Django settings
The new connection can be created based on a Site Setting or just hardcoded.