### PR TITLE
Fix submit form with file uploads for anonymous users

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1178,6 +1178,10 @@ class CoderedFormMixin(models.Model):
             if type(val) == InMemoryUploadedFile or type(val) == TemporaryUploadedFile:
                 # Save the file and get its URL
 
+                # Custom code to ensure that anonymous users get a session key.
+                if not request.session.session_key:
+                    request.session.create()
+
                 directory = request.session.session_key
                 storage = self.get_storage()
                 Path(storage.path(directory)).mkdir(parents=True,


### PR DESCRIPTION
#### Description of change
Explain what you changed, and how or why it works the way it does.
submitting a form as anonymous user doesn't work. (error 500)
The problem is that the anonymous user doesn't have a session  yet

