### PR TITLE
Fix search 500 error with invalid query

### DIFF
--- a/coderedcms/tests/test_urls.py
+++ b/coderedcms/tests/test_urls.py
@@ -47,7 +47,14 @@ class TestSiteURLs(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(response.context['results'], None)
 
-        response = self.client.get("/search/?s=keyword&t=t")
+        response = self.client.get(reverse(
+            'codered_search'),
+            {
+                's': 'keyword',
+                't': 't',
+            },
+            follow=False
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['results'], None)
 

--- a/coderedcms/tests/test_urls.py
+++ b/coderedcms/tests/test_urls.py
@@ -47,6 +47,10 @@ class TestSiteURLs(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(response.context['results'], None)
 
+        response = self.client.get("/search/?s=keyword&t=t")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['results'], None)
+
 
 @pytest.mark.django_db
 class TestEventURLs(unittest.TestCase):

--- a/coderedcms/views.py
+++ b/coderedcms/views.py
@@ -74,7 +74,7 @@ def search(request):
                 try:
                     model = ContentType.objects.get(model=search_model).model_class()
                     results = model.objects.live().search(search_query)
-                except search_model.DoesNotExist:
+                except ContentType.DoesNotExist:
                     results = None
             else:
                 results = CoderedPage.objects.live().order_by('-last_published_at').search(search_query)  # noqa


### PR DESCRIPTION
Fixes #387 

#### Description of change
1) Updated the exception in search to be contentype.doesnotexist so that if someone adds search parameters into the search URL, it returns a 200 page with "no results found" instead of Internal Service Error
2) Added the test for it in the test_search function in test_urls.py

#### Documentation
n/a

#### Tests
Test added to the def test_search function to test for "/search/?s=keyword&t=t"
Also tested this manually and it works. The search box was fine. It was a bug when people typed in search parameters in the URL for search.
