### PR TITLE
Wagtail upgrade

### DIFF
--- a/coderedcms/__init__.py
+++ b/coderedcms/__init__.py
@@ -14,7 +14,7 @@ Maintains version of coderedcms.
 
 See: https://www.python.org/dev/peps/pep-0440/
 """
-release = ["0", "20", "0", "", ""]
+release = ["0", "20", "0", "dev2", ""]
 
 
 def _get_version() -> str:

--- a/coderedcms/wagtail_flexible_forms/blocks.py
+++ b/coderedcms/wagtail_flexible_forms/blocks.py
@@ -3,7 +3,7 @@ from django.db.models import BLANK_CHOICE_DASH
 from django.utils.dateparse import parse_datetime
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
-from unidecode import unidecode
+from anyascii import anyascii
 from wagtail.core.blocks import (
     StructBlock, TextBlock, CharBlock, BooleanBlock, ListBlock, StreamBlock,
     DateBlock, TimeBlock, DateTimeBlock, ChoiceBlock, RichTextBlock,
@@ -18,7 +18,7 @@ class FormFieldBlock(StructBlock):
     widget = None
 
     def get_slug(self, struct_value):
-        return slugify(unidecode(struct_value['field_label']))
+        return slugify(anyascii(struct_value['field_label']))
 
     def get_field_class(self, struct_value):
         return self.field_class

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Django>=2.2,<3.2',             # should be the same as wagtail
         'geocoder==1.38.*',
         'icalendar==4.0.*',
-        'wagtail==2.11.*',
+        'wagtail==2.12',
         'wagtailfontawesome>=1.2.*',
         'wagtail-cache==1.*',
         'wagtail-import-export>=0.2,<0.3'

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
         'Django>=2.2,<3.2',             # should be the same as wagtail
         'geocoder==1.38.*',
         'icalendar==4.0.*',
-        'wagtail==2.12',
+        'unidecode==1.*',
+        'wagtail==2.12.*',
         'wagtailfontawesome>=1.2.*',
         'wagtail-cache==1.*',
         'wagtail-import-export>=0.2,<0.3'

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Django>=2.2,<3.2',             # should be the same as wagtail
         'geocoder==1.38.*',
         'icalendar==4.0.*',
-        'unidecode==1.*',
         'wagtail==2.12.*',
         'wagtailfontawesome>=1.2.*',
         'wagtail-cache==1.*',


### PR DESCRIPTION
For issue #409 

#### Description of change
Updated required Wagtail version.
Also added unidecode in settings since it was not automatically found otherwise, used in blocks.py

#### Tests
Ran the pytest unit tests, all 56 passed with 40 deprecation warnings from Django (some of it from packages).
Also ran the testproject and it all still works, and CSS looks fine too. 
Note that wagtail-import-export is no longer maintained but that will be a separate issue.  It still seems to work for now, though. 

**Will need to change version number but you can test it yourself first.
