### PR TITLE
Fix foot menu position

### DIFF
--- a/coderedcms/static/coderedcms/css/codered-admin.css
+++ b/coderedcms/static/coderedcms/css/codered-admin.css
@@ -252,11 +252,11 @@ input[type='checkbox']::before, input[type='radio']::before {
         margin-top:0.9em;
         font-size: 0.9em;
     }
-    .nav-main .footer-submenu {
+    .nav-main .nav-footer-submenu {
         overflow: hidden;
         display: block;
     }
-    .footer .avatar {
+    .nav-footer .avatar {
         width: 40px;
         height: 40px;
     }

--- a/coderedcms/templates/wagtailadmin/shared/main_nav.html
+++ b/coderedcms/templates/wagtailadmin/shared/main_nav.html
@@ -3,7 +3,7 @@
     <ul>
         {{ menu_html }}
 
-        <li class="footer" id="footer">
+        <li class="nav-footer" id="footer">
             <div class="account" id="account-settings" title="{% trans 'Edit your account' %}">
                 <span class="avatar square avatar-on-dark">
                     <img src="{% avatar_url request.user size=50 %}" alt="" />
@@ -11,7 +11,7 @@
                 <em class="icon icon-arrow-up-after">{{ request.user.first_name|default:request.user.get_username }}</em>
             </div>
 
-            <ul class="footer-submenu">
+            <ul class="nav-footer-submenu">
                 <li><a href="{% url 'wagtailadmin_account' %}" class="icon icon-user">{% trans "Account settings" %}</a></li>
                 <li><a href="{% url 'wagtailadmin_logout' %}" class="icon icon-logout">{% trans "Log out" %}</a></li>
             </ul>

--- a/docs/features/page_types/article_pages.rst
+++ b/docs/features/page_types/article_pages.rst
@@ -18,7 +18,7 @@ Layout Tab
 * **Show Images**:  If toggled on, this landing page will show the cover images for its children articles.
 * **Show Captions**: If toggled on, this landing page will show the captions for its children articles.
 * **Show Author and Date Info**: If toggled on, this landing page will show the captions for its children articles.
-* **Show Preview Text**: If toggled on, this landing page will show a preview of its childrens content.
+* **Show Preview Text**: If toggled on, this landing page will show a preview of its children's content.
 
 
 Article Page


### PR DESCRIPTION
#### Description of change

Foot menu items on branch wagtail-upgrade213 is not pinned to the bottom.

Wagtail 2.13 uses 'nav-footer' and 'nav-footer-menu' classes instead of the current 'footer' and 'footer-menu' class in coderedcms.
