### PR TITLE
Upgrade to Wagtail 2.14

### DIFF
--- a/docs/releases/v0.22.0.rst
+++ b/docs/releases/v0.22.0.rst
@@ -5,9 +5,14 @@ v0.22.0 release notes
 New features
 ------------
 
+* Upgraded to Wagtail 2.14
+
 
 Upgrade considerations
 ----------------------
+
+* Wagtail 2.14 dropped Django 2.2 support. For most CodeRed CMS sites no changes
+  are required.
 
 
 Supported software
@@ -15,7 +20,7 @@ Supported software
 
 * Python 3.6, 3.7, 3.8, 3.9
 
-* Django 2.2, 3.0, 3.1, 3.2
+* Django 3.0, 3.1, 3.2
 
 
 Thank you!

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,10 @@ setup(
         'beautifulsoup4>=4.8,<4.10',    # should be the same as wagtail
         'django-eventtools==1.0.*',
         'django-bootstrap4>=2.0,<2.4',
-        'Django>=2.2,<3.3',             # should be the same as wagtail
+        'Django>=3.0,<3.3',             # should be the same as wagtail
         'geocoder==1.38.*',
         'icalendar==4.0.*',
-        'wagtail==2.13.*',
+        'wagtail==2.14.*',
         'wagtailfontawesome>=1.2.*',
         'wagtail-cache==1.*',
         'wagtail-import-export>=0.2,<0.3',


### PR DESCRIPTION
As far as I can tell, there are no major changes from 2.13 -> 2.14, so it is an easy upgrade. Fixes #428 .

Everything seems to visually work in the admin.

I did patch in #431 which I discovered while auditing 2.14 changes, so that has been merged into dev and backported to 0.21.1.