### PR TITLE
Clear wagtailcache on page and snippet changes

### DIFF
--- a/coderedcms/wagtail_hooks.py
+++ b/coderedcms/wagtail_hooks.py
@@ -34,11 +34,20 @@ def collapsible_js():
     return format_html('<script src="{}"></script>', static('coderedcms/js/codered-editor.js'))
 
 
-@hooks.register('after_create_page')
-@hooks.register('after_edit_page')
-def clear_wagtailcache(request, page):
-    if page.live:
-        clear_cache()
+def clear_wagtailcache(*args, **kwargs):
+    clear_cache()
+
+
+# Clear cache whenever pages/snippets are changed. Err on the side of clearing
+# the cache vs not clearing the cache, as this usually leads to support requests
+# when staff members make edits but do not see the changes.
+hooks.register('after_delete_page', clear_wagtailcache)
+hooks.register('after_move_page', clear_wagtailcache)
+hooks.register('after_publish_page', clear_wagtailcache)
+hooks.register('after_unpublish_page', clear_wagtailcache)
+hooks.register('after_create_snippet', clear_wagtailcache)
+hooks.register('after_edit_snippet', clear_wagtailcache)
+hooks.register('after_delete_snippet', clear_wagtailcache)
 
 
 @hooks.register('filter_form_submissions_for_user')

--- a/docs/releases/v0.22.0.rst
+++ b/docs/releases/v0.22.0.rst
@@ -18,6 +18,13 @@ New features
   See :doc:`/how_to/add_tracking_scripts`.
 
 
+Bug fixes
+---------
+
+* Cache is now cleared more reliably whenever pages or snippets are created,
+  edited, published, unpublished, or deleted.
+
+
 Upgrade considerations
 ----------------------
 


### PR DESCRIPTION
Fixes #434 

Previously we were only clearing the cache when pages were created or edited.

Now we will clear the cache whenever pages are: published, unpublished, moved, deleted; or snippets are: created, edited, deleted.

This should help make the cache more invisible to editors who sometimes need to file support requests because changes are not immediately visible across the site.