### PR TITLE
Cache-bust provided css/js files

### DIFF
--- a/coderedcms/static/coderedcms/js/codered-front.js
+++ b/coderedcms/static/coderedcms/js/codered-front.js
@@ -35,11 +35,11 @@ libs = {
         head: '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.9.0/main.min.css" integrity="sha256-FjyLCG3re1j4KofUTQQXmaWJw13Jdb7LQvXlkFxTDJI=" crossorigin="anonymous">'
     },
     coderedmaps: {
-        url: "/static/coderedcms/js/codered-maps.js",
+        url: "/static/coderedcms/js/codered-maps.js?v=" + cr_version,
         integrity: "",
     },
     coderedstreamforms: {
-        url: "/static/coderedcms/js/codered-streamforms.js",
+        url: "/static/coderedcms/js/codered-streamforms.js?v=" + cr_version,
         integrity: "",
     }
 }

--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -48,6 +48,7 @@
         <script>
             cr_site_url = "{{site.root_url}}";
             cr_external_new_tab = {{settings.coderedcms.GeneralSettings.external_new_tab|yesno:"true,false"}};
+            cr_version = "{% coderedcms_version %}";
         </script>
 
         <meta charset="utf-8" />
@@ -67,9 +68,9 @@
 
         {% block coderedcms_assets %}
         {% if "DEBUG"|django_settings %}
-        <link rel="stylesheet" type="text/css" href="{% static 'coderedcms/css/codered-front.css' %}">
+        <link rel="stylesheet" type="text/css" href="{% static 'coderedcms/css/codered-front.css' %}?v={% coderedcms_version %}">
         {% else %}
-        <link rel="stylesheet" type="text/css" href="{% static 'coderedcms/css/codered-front.min.css' %}">
+        <link rel="stylesheet" type="text/css" href="{% static 'coderedcms/css/codered-front.min.css' %}?v={% coderedcms_version %}">
         {% endif %}
         {% endblock %}
 
@@ -160,15 +161,15 @@
         {% block footer %}{% endblock %}
 
         {% block required_scripts %}
-        <script src="{% static 'coderedcms/vendor/jquery/jquery-3.5.1.min.js' %}" ></script>
+        <script src="{% static 'coderedcms/vendor/jquery/jquery-3.5.1.min.js' %}?v={% coderedcms_version %}" ></script>
         {% endblock %}
 
         {% block frontend_scripts %}
-        <script src="{% static 'coderedcms/vendor/bootstrap/dist/js/bootstrap.min.js' %}"></script>
+        <script src="{% static 'coderedcms/vendor/bootstrap/dist/js/bootstrap.min.js' %}?v={% coderedcms_version %}"></script>
         {% endblock %}
 
         {% block coderedcms_scripts %}
-        <script type="text/javascript" src="{% static 'coderedcms/js/codered-front.js' %}"></script>
+        <script type="text/javascript" src="{% static 'coderedcms/js/codered-front.js' %}?v={% coderedcms_version %}"></script>
         {% endblock %}
 
         {% block custom_scripts %}

--- a/coderedcms/wagtail_hooks.py
+++ b/coderedcms/wagtail_hooks.py
@@ -10,28 +10,35 @@ from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy, get_page_models
 from wagtailcache.cache import clear_cache
 
+from coderedcms import __version__
 from coderedcms.wagtail_flexible_forms.wagtail_hooks import FormAdmin, SubmissionAdmin
 
 
 @hooks.register('insert_global_admin_css')
 def global_admin_css():
     return format_html(
-        '<link rel="stylesheet" type="text/css" href="{}">',
-        static('coderedcms/css/codered-admin.css')
+        '<link rel="stylesheet" type="text/css" href="{}?v={}">',
+        static('coderedcms/css/codered-admin.css'),
+        __version__,
     )
 
 
 @hooks.register('insert_editor_css')
 def editor_css():
     return format_html(
-        '<link rel="stylesheet" type="text/css" href="{}">',
-        static('coderedcms/css/codered-editor.css')
+        '<link rel="stylesheet" type="text/css" href="{}?v={}">',
+        static('coderedcms/css/codered-editor.css'),
+        __version__,
     )
 
 
 @hooks.register('insert_editor_js')
 def collapsible_js():
-    return format_html('<script src="{}"></script>', static('coderedcms/js/codered-editor.js'))
+    return format_html(
+        '<script src="{}?v={}"></script>',
+        static('coderedcms/js/codered-editor.js'),
+        __version__,
+    )
 
 
 def clear_wagtailcache(*args, **kwargs):

--- a/docs/releases/v0.22.0.rst
+++ b/docs/releases/v0.22.0.rst
@@ -28,6 +28,9 @@ Bug fixes
   and other related improvements to event handling. See
   :doc:`/features/page_types/event_pages`.
 
+* CSS/JS files provided by CodeRed CMS are now cache-busted by version number.
+  This should help resolve minor inconsistencies that arise between upgrades.
+
 
 Maintenance
 -----------


### PR DESCRIPTION
#### Description of change
This should have been done long ago, but it now adds a version identifier as a querystring on all css/js files which are part of the coderedcms package, to ensure that they are re-fetched by the browser after upgrading coderedcms on a client site. E.g.

```
/codered-front.js?v=0.22.0
```

#### Tests
Tested locally and confirmed presence of querystrings.