### PR TITLE
Fix form summary emails

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1289,11 +1289,11 @@ class CoderedFormMixin(models.Model):
         addresses = [x.strip() for x in self.to_address.split(',')]
         content = []
 
-        for key, value in self.data_to_dict(processed_data, request).items():
-            content.append('{0}: {1}'.format(
-                key.replace('_', ' ').title(),
-                value
-            ))
+        for field in self.get_form_fields():
+            key = field.clean_name
+            label = field.label
+            value = processed_data.get(key)
+            content.append('{0}: {1}'.format(label, value))
 
         content = '\n-------------------- \n'.join(content)
 
@@ -1318,7 +1318,12 @@ class CoderedFormMixin(models.Model):
         # Send email
         self.send_mail(request, message_args)
 
-    def send_mail(self, resuest, message_args, content_subtype='text'):
+    def send_mail(
+        self,
+        resuest,
+        message_args: dict,
+        content_subtype: Optional[str] = None
+    ):
         """
         Utility to send email messages from form submissions.
 
@@ -1326,7 +1331,8 @@ class CoderedFormMixin(models.Model):
         way or using a different backend as needed.
         """
         message = EmailMessage(**message_args)
-        message.content_subtype = content_subtype
+        if content_subtype:
+            message.content_subtype = content_subtype
         message.send()
 
     def render_landing_page(self, request, form_submission=None):

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -18,6 +18,7 @@ CodeRed CMS follows the ``[major].[minor].[maintenance]`` versioning scheme.
     :maxdepth: 1
 
     v0.23.0
+    v0.22.2
     v0.22.1
     v0.22.0
     v0.21.1

--- a/docs/releases/v0.22.2.rst
+++ b/docs/releases/v0.22.2.rst
@@ -1,4 +1,4 @@
-v0.22.1 release notes
+v0.22.2 release notes
 =====================
 
 

--- a/docs/releases/v0.22.2.rst
+++ b/docs/releases/v0.22.2.rst
@@ -1,0 +1,12 @@
+v0.22.1 release notes
+=====================
+
+
+Bug fixes
+---------
+
+* Form submission email contents were empty and being attached in a text file.
+  The contents are now in the email as expected (Bug was introduced in 0.22.0).
+
+* Field labels in form submission emails now show the exact label as entered
+  on the Wagtail page, instead of a "humanized" version of the field ID.


### PR DESCRIPTION
Due to a refactor in the form email sending functionality, an invalid content subtype was being set on the message for plaintext emails. Therefore form submission emails appeared to have no contents, and the contents were instead attached as a text file. This fix corrects the content subtype attribute.

This change also fixes a related but separate behavior to correctly display the field labels within the summary email message. Previously they were being humanized from the dict key (e.g. replace underscores with spaces). Now they are being pulled from the actual form labels.

#### Tests
Manually tested, using Outlook email client.
