### PR TITLE
Fix email sending of form page models which provide custom get_form_fields() method

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1288,18 +1288,20 @@ class CoderedFormMixin(models.Model):
         """
         addresses = [x.strip() for x in self.to_address.split(',')]
         content = []
+        data = self.data_to_dict(processed_data, request)
 
-        for field in self.get_form_fields():
-            key = field.clean_name
+        for field in form:
+            # Get key from form, transform same as data_to_dict() does.
+            key = field.html_name.replace('-', '_')
             label = field.label
-            value = processed_data.get(key)
+            value = data.get(key)
             content.append('{0}: {1}'.format(label, value))
 
-        content = '\n-------------------- \n'.join(content)
+        content_str = '\n-------------------- \n'.join(content) + '\n'
 
         # Build email message parameters
         message_args = {
-            'body': content,
+            'body': content_str,
             'to': addresses,
         }
         if self.subject:
@@ -1311,7 +1313,7 @@ class CoderedFormMixin(models.Model):
             message_args['from_email'] = genemail
         if self.reply_address:
             # Render reply-to field using form submission as context.
-            context = Context(self.data_to_dict(processed_data, request))
+            context = Context(data)
             template_reply_to = Template(self.reply_address)
             message_args['reply_to'] = template_reply_to.render(context).split(',')
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -18,6 +18,7 @@ CodeRed CMS follows the ``[major].[minor].[maintenance]`` versioning scheme.
     :maxdepth: 1
 
     v0.23.0
+    v0.22.3
     v0.22.2
     v0.22.1
     v0.22.0

--- a/docs/releases/v0.22.3.rst
+++ b/docs/releases/v0.22.3.rst
@@ -1,0 +1,10 @@
+v0.22.3 release notes
+=====================
+
+
+Bug fixes
+---------
+
+* Form submission emails were broken on custom form pages which override
+  ``get_form_fields()`` and do not return fields as classes inheriting
+  ``AbstractFormField`` (Bug was introduced in 0.22.2).


### PR DESCRIPTION
Due to change in 0.22.2, forms which override `get_form_fields()` method and do NOT return fields as `AbstractFormField` class would cause breakage while sending the summary email. Now, the actual Django form object is used instead rather than the `get_form_fields()` method, which should make it more widely compatible with custom page types.