### PR TITLE
Prevent upward path traversals when serving protected media

### DIFF
--- a/coderedcms/views.py
+++ b/coderedcms/views.py
@@ -111,8 +111,12 @@ def serve_protected_file(request, path):
     """
     Function that serves protected files uploaded from forms.
     """
-    fullpath = os.path.join(cr_settings['PROTECTED_MEDIA_ROOT'], path)
-    if os.path.isfile(fullpath):
+    # Fully resolve all provided paths.
+    mediapath = os.path.abspath(cr_settings['PROTECTED_MEDIA_ROOT'])
+    fullpath = os.path.abspath(os.path.join(mediapath, path))
+
+    # Path must be a sub-path of the PROTECTED_MEDIA_ROOT, and exist.
+    if fullpath.startswith(mediapath) and os.path.isfile(fullpath):
         mimetype, encoding = mimetypes.guess_type(fullpath)
         with open(fullpath, 'rb') as f:
             response = HttpResponse(f.read(), content_type=mimetype)

--- a/docs/releases/v0.22.3.rst
+++ b/docs/releases/v0.22.3.rst
@@ -8,3 +8,7 @@ Bug fixes
 * Form submission emails were broken on custom form pages which override
   ``get_form_fields()`` and do not return fields as classes inheriting
   ``AbstractFormField`` (Bug was introduced in 0.22.2).
+
+* Prevent upward path traversals outside of ``CODERED_PROTECTED_MEDIA_ROOT``
+  when serving protected media files. This only applies to logged in users,
+  anonymous users do not have permission to access this URL.


### PR DESCRIPTION
Fixes issue #448 