### PR TITLE
added upgrade consideration to coderedcms v. 0.20.0 release notes

### DIFF
--- a/docs/releases/v0.20.0.rst
+++ b/docs/releases/v0.20.0.rst
@@ -28,6 +28,9 @@ Upgrade considerations
   issues after updating. See `Wagtail 2.11 release notes
   <https://docs.wagtail.io/en/stable/releases/2.11.html#run-before-declaration-needed-in-initial-homepage-migration>`_.
 
+* If you have forms and form submissions in your database, you may need to add the ``unidecode`` library to your project's ``requirements.txt``.
+  Wagtail 2.11 replaces ``unidecode`` with ``anyascii`` for Unicode to Ascii conversion. Your older form data will still need the ``unidecode`` library
+  to be read by Wagtail. Read more in the `Wagtail 2.11 notes for other features <https://docs.wagtail.io/en/stable/releases/2.11.html#other-features>`_.
 
 Thank you!
 ----------


### PR DESCRIPTION

#### Documentation
Added upgrade consideration to coderedcms v. 0.20.0 release notes
documentation, please provide a description here instead. Upgrading from 0.19.0 to newer versions of CoderedCMS causes an issue with forms/form data because of the upgrade to Wagtail 2.11. 

