### PR TITLE
Issue433/imageblock

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/hero_block.html
+++ b/coderedcms/templates/coderedcms/blocks/hero_block.html
@@ -4,7 +4,7 @@
 <div class="container">
 {% endif %}
 
-{% image self.background_image max-2000x2000 as background_image %}
+{% image self.background_image original as background_image %}
 <div class="hero-bg {% if self.is_parallax %}parallax{% endif %} {% if self.tile_image %}tile{% endif %} {{self.settings.custom_css_class}}"
     style="{% if self.background_color %}background-color:{{self.background_color}};{% endif %}{% if background_image %}background-image:url({{background_image.url}});{% endif %}"
     {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>

--- a/coderedcms/templates/coderedcms/blocks/image_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_block.html
@@ -1,6 +1,6 @@
 {% load wagtailimages_tags %}
 
-{% image self.image max-1000x1000 as self_image %}
+{% image self.image original as self_image %}
 
 {% if format == 'amp' %}
 

--- a/coderedcms/templates/coderedcms/blocks/image_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_link_block.html
@@ -6,6 +6,6 @@
         data-ga-event-label='{{self.settings.ga_tracking_event_label|default:self.alt_text}}'
     {% endif %}
     title="{{ self.alt_text|safe }}" {% if self.settings.custom_id %}id="{{ self.settings.custom_id }}" {% endif %}>
-    {% image self.image max-1000x1000 as self_image %}
+    {% image self.image original as self_image %}
     <img src="{{self_image.url}}" class="img-fluid {{self.settings.custom_css_class}}" alt="{{self.alt_text|safe}}" />
 </a>

--- a/coderedcms/templates/coderedcms/pages/article_page.html
+++ b/coderedcms/templates/coderedcms/pages/article_page.html
@@ -5,7 +5,7 @@
 {% block content %}
     <article class="codered-article {%if self.cover_image %}has-img{% endif %}">
         {% if self.cover_image %}
-        {% image self.cover_image orignal as cover_image %}
+        {% image self.cover_image original as cover_image %}
         <img src="{{cover_image.url}}" class="w-100" />
         {% endif %}
         <div class="container">

--- a/coderedcms/templates/coderedcms/pages/article_page.html
+++ b/coderedcms/templates/coderedcms/pages/article_page.html
@@ -5,7 +5,7 @@
 {% block content %}
     <article class="codered-article {%if self.cover_image %}has-img{% endif %}">
         {% if self.cover_image %}
-        {% image self.cover_image fill-2000x1000 as cover_image %}
+        {% image self.cover_image orignal as cover_image %}
         <img src="{{cover_image.url}}" class="w-100" />
         {% endif %}
         <div class="container">

--- a/coderedcms/templates/coderedcms/pages/web_page.html
+++ b/coderedcms/templates/coderedcms/pages/web_page.html
@@ -3,7 +3,7 @@
 
 {% block content_pre_body %}
   {% if self.cover_image %}
-  {% image page.cover_image fill-2000x1000 as cover_image %}
+  {% image page.cover_image original as cover_image %}
   <div class="hero-bg mb-5" style="background-image:url({{cover_image.url}});">
     <div class="hero-fg">
       <div class="container">


### PR DESCRIPTION

#### Description of change
Updated page cover images, image block, image link block, and hero block to use original image size instead of pre-cropping.
This way images aren't stretched or warped. 

Issue #433 

