### PR TITLE
Remove traces of old AMP code

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/button_block.html
+++ b/coderedcms/templates/coderedcms/blocks/button_block.html
@@ -1,5 +1,5 @@
 <a href="{{self.url}}"
-    {% if settings.coderedcms.AnalyticsSettings.ga_track_button_clicks and not format == 'amp' %}
+    {% if settings.coderedcms.AnalyticsSettings.ga_track_button_clicks %}
         data-ga-event-category='{{self.settings.ga_tracking_event_category|default:"Button"}}'
         data-ga-event-label='{{self.settings.ga_tracking_event_label|default:self.button_title}}'
     {% endif %}

--- a/coderedcms/templates/coderedcms/blocks/download_block.html
+++ b/coderedcms/templates/coderedcms/blocks/download_block.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags %}
 
 <a href="{{self.downloadable_file.url}}" download="{{self.downloadable_file.url}}"
-    {% if settings.coderedcms.AnalyticsSettings.ga_track_button_clicks and not format == 'amp' %}
+    {% if settings.coderedcms.AnalyticsSettings.ga_track_button_clicks %}
         data-ga-event-category='{{self.settings.ga_tracking_event_category|default:"Download"}}'
         data-ga-event-label='{{self.settings.ga_tracking_event_label|default:self.button_title}}'
     {% endif %}
@@ -15,7 +15,7 @@
 {% endif %}
 </a>
 
-{% if self.automatic_download and not format == 'amp' %}
+{% if self.automatic_download %}
 <script>
     $(document).ready(function(){
         window.open("{{self.downloadable_file.url}}", '_blank');

--- a/coderedcms/templates/coderedcms/blocks/image_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_block.html
@@ -2,19 +2,7 @@
 
 {% image self.image max-1000x1000 as self_image %}
 
-{% if format == 'amp' %}
-
-<amp-img src="{{self_image.url}}"
-layout="responsive" width="{{self_image.width}}" height="{{self_image.height}}"
-class="{{self.settings.custom_css_class}}"
-{% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}
-alt="{{self_image.image.title}}"></amp-img>
-
-{% else %}
-
 <img src="{{self_image.url}}"
 class="w-100 {{self.settings.custom_css_class}}"
 {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}
 alt="{{self_image.image.title}}" />
-
-{% endif %}

--- a/coderedcms/templates/coderedcms/blocks/image_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_link_block.html
@@ -1,7 +1,7 @@
 {% load wagtailimages_tags %}
 
 <a href="{{self.url}}"
-    {% if settings.coderedcms.AnalyticsSettings.ga_track_button_clicks and not format == 'amp' %}
+    {% if settings.coderedcms.AnalyticsSettings.ga_track_button_clicks %}
         data-ga-event-category='{{self.settings.ga_tracking_event_category|default:"ImageLink"}}'
         data-ga-event-label='{{self.settings.ga_tracking_event_label|default:self.alt_text}}'
     {% endif %}

--- a/coderedcms/templates/coderedcms/snippets/footer.html
+++ b/coderedcms/templates/coderedcms/snippets/footer.html
@@ -5,7 +5,7 @@
 {% for footer in footers %}
     <div {% if footer.custom_id %} id="{{footer.custom_id}}"{% endif %} {% if footer.custom_css_class %} class="{{footer.custom_css_class}}"{% endif %}>
         {% for item in footer.content %}
-            {% include_block item with format=format settings=settings %}
+            {% include_block item with settings=settings %}
         {% endfor %}
     </div>
 {% endfor %}


### PR DESCRIPTION
As of the past few releases we dropped support for dynamically rendering AMP code in HTML templates. Just a bit of cleanup to remove some lingering dead code.
