### PR TITLE
fix orderables, need to inherit Meta to work correctly

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1042,7 +1042,7 @@ class CoderedEventIndexPage(CoderedWebPage):
 
 
 class CoderedEventOccurrence(Orderable, BaseOccurrence):
-    class Meta:
+    class Meta(Orderable.Meta):
         verbose_name = _('CodeRed Event Occurrence')
         abstract = True
 

--- a/coderedcms/models/snippet_models.py
+++ b/coderedcms/models/snippet_models.py
@@ -79,7 +79,7 @@ class CarouselSlide(Orderable, models.Model):
     Represents a slide for the Carousel model. Can be modified through the
     snippets UI.
     """
-    class Meta:
+    class Meta(Orderable.Meta):
         verbose_name = _('Carousel Slide')
 
     carousel = ParentalKey(
@@ -172,7 +172,7 @@ class ClassifierTerm(Orderable, models.Model):
     """
     Term used to categorize a page.
     """
-    class Meta:
+    class Meta(Orderable.Meta):
         verbose_name = _('Classifier Term')
         verbose_name_plural = _('Classifier Terms')
 


### PR DESCRIPTION
#### Description of change
Make orderables save correctly the order. Due to the overwritting of Meta class, orderables didn't have the needed ordering variable. Here is the description of the [Orderable bug](https://github.com/wagtail/wagtail/issues/1749) in Wagtail repo.

#### Documentation
N/A

#### Tests
N/A
