### PR TITLE
Search all Wagtail Page models

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -126,7 +126,7 @@ class CoderedPageMeta(PageBase):
     def search_db_include(self):
         warnings.warn(
             (
-                "This attribute of CoderedPageMeta has been depricated in favor of"
+                "This attribute of CoderedPageMeta has been deprecated in favor of"
                 " Wagtail's included search functionality."
             ),
             DeprecationWarning,
@@ -137,7 +137,7 @@ class CoderedPageMeta(PageBase):
     def search_db_boost(self):
         warnings.warn(
             (
-                "This attribute of CoderedPageMeta has been depricated in favor of"
+                "This attribute of CoderedPageMeta has been deprecated in favor of"
                 " Wagtail's included search functionality."
             ),
             DeprecationWarning,
@@ -148,7 +148,7 @@ class CoderedPageMeta(PageBase):
     def search_name(self):
         warnings.warn(
             (
-                "This attribute of CoderedPageMeta has been depricated in favor of"
+                "This attribute of CoderedPageMeta has been deprecated in favor of"
                 " Wagtail's included search functionality."
             ),
             DeprecationWarning,
@@ -159,7 +159,7 @@ class CoderedPageMeta(PageBase):
     def search_name_plural(self):
         warnings.warn(
             (
-                "This attribute of CoderedPageMeta has been depricated in favor of"
+                "This attribute of CoderedPageMeta has been deprecated in favor of"
                 " Wagtail's included search functionality."
             ),
             DeprecationWarning,

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -107,16 +107,8 @@ def get_page_models():
 class CoderedPageMeta(PageBase):
     def __init__(cls, name, bases, dct):
         super().__init__(name, bases, dct)
-        if 'search_db_include' not in dct:
-            cls._search_db_include = False
-        if 'search_db_boost' not in dct:
-            cls._search_db_boost = 0
         if 'search_filterable' not in dct:
             cls.search_filterable = False
-        if 'search_name' not in dct:
-            cls._search_name = cls._meta.verbose_name
-        if 'search_name_plural' not in dct:
-            cls._search_name_plural = cls._meta.verbose_name_plural
         if 'search_template' not in dct:
             cls.search_template = 'coderedcms/pages/search_result.html'
         if not cls._meta.abstract:
@@ -131,7 +123,7 @@ class CoderedPageMeta(PageBase):
             ),
             DeprecationWarning,
         )
-        return self._search_db_include
+        return False
 
     @property
     def search_db_boost(self):
@@ -142,7 +134,7 @@ class CoderedPageMeta(PageBase):
             ),
             DeprecationWarning,
         )
-        return self._search_db_boost
+        return 0
 
     @property
     def search_name(self):
@@ -153,7 +145,7 @@ class CoderedPageMeta(PageBase):
             ),
             DeprecationWarning,
         )
-        return self._search_name
+        return self._meta.verbose_name
 
     @property
     def search_name_plural(self):
@@ -164,7 +156,7 @@ class CoderedPageMeta(PageBase):
             ),
             DeprecationWarning,
         )
-        return self._search_name_plural
+        return self._meta.verbose_name_plural
 
 
 class CoderedTag(TaggedItemBase):

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -108,19 +108,63 @@ class CoderedPageMeta(PageBase):
     def __init__(cls, name, bases, dct):
         super().__init__(name, bases, dct)
         if 'search_db_include' not in dct:
-            cls.search_db_include = False
+            cls._search_db_include = False
         if 'search_db_boost' not in dct:
-            cls.search_db_boost = 0
+            cls._search_db_boost = 0
         if 'search_filterable' not in dct:
             cls.search_filterable = False
         if 'search_name' not in dct:
-            cls.search_name = cls._meta.verbose_name
+            cls._search_name = cls._meta.verbose_name
         if 'search_name_plural' not in dct:
-            cls.search_name_plural = cls._meta.verbose_name_plural
+            cls._search_name_plural = cls._meta.verbose_name_plural
         if 'search_template' not in dct:
             cls.search_template = 'coderedcms/pages/search_result.html'
         if not cls._meta.abstract:
             CODERED_PAGE_MODELS.append(cls)
+
+    @property
+    def search_db_include(self):
+        warnings.warn(
+            (
+                "This attribute of CoderedPageMeta has been depricated in favor of"
+                " Wagtail's included search functionality."
+            ),
+            DeprecationWarning,
+        )
+        return self._search_db_include
+
+    @property
+    def search_db_boost(self):
+        warnings.warn(
+            (
+                "This attribute of CoderedPageMeta has been depricated in favor of"
+                " Wagtail's included search functionality."
+            ),
+            DeprecationWarning,
+        )
+        return self._search_db_boost
+
+    @property
+    def search_name(self):
+        warnings.warn(
+            (
+                "This attribute of CoderedPageMeta has been depricated in favor of"
+                " Wagtail's included search functionality."
+            ),
+            DeprecationWarning,
+        )
+        return self._search_name
+
+    @property
+    def search_name_plural(self):
+        warnings.warn(
+            (
+                "This attribute of CoderedPageMeta has been depricated in favor of"
+                " Wagtail's included search functionality."
+            ),
+            DeprecationWarning,
+        )
+        return self._search_name_plural
 
 
 class CoderedTag(TaggedItemBase):

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -109,6 +109,10 @@ class CoderedPageMeta(PageBase):
         super().__init__(name, bases, dct)
         if 'search_filterable' not in dct:
             cls.search_filterable = False
+        if 'search_name' not in dct:
+            cls.search_name = cls._meta.verbose_name
+        if 'search_name_plural' not in dct:
+            cls.search_name_plural = cls._meta.verbose_name_plural
         if 'search_template' not in dct:
             cls.search_template = 'coderedcms/pages/search_result.html'
         if not cls._meta.abstract:
@@ -135,28 +139,6 @@ class CoderedPageMeta(PageBase):
             DeprecationWarning,
         )
         return 0
-
-    @property
-    def search_name(self):
-        warnings.warn(
-            (
-                "This attribute of CoderedPageMeta has been deprecated in favor of"
-                " Wagtail's included search functionality."
-            ),
-            DeprecationWarning,
-        )
-        return self._meta.verbose_name
-
-    @property
-    def search_name_plural(self):
-        warnings.warn(
-            (
-                "This attribute of CoderedPageMeta has been deprecated in favor of"
-                " Wagtail's included search functionality."
-            ),
-            DeprecationWarning,
-        )
-        return self._meta.verbose_name_plural
 
 
 class CoderedTag(TaggedItemBase):

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -107,38 +107,8 @@ def get_page_models():
 class CoderedPageMeta(PageBase):
     def __init__(cls, name, bases, dct):
         super().__init__(name, bases, dct)
-        if 'search_filterable' not in dct:
-            cls.search_filterable = False
-        if 'search_name' not in dct:
-            cls.search_name = cls._meta.verbose_name
-        if 'search_name_plural' not in dct:
-            cls.search_name_plural = cls._meta.verbose_name_plural
-        if 'search_template' not in dct:
-            cls.search_template = 'coderedcms/pages/search_result.html'
         if not cls._meta.abstract:
             CODERED_PAGE_MODELS.append(cls)
-
-    @property
-    def search_db_include(self):
-        warnings.warn(
-            (
-                "This attribute of CoderedPageMeta has been deprecated in favor of"
-                " Wagtail's included search functionality."
-            ),
-            DeprecationWarning,
-        )
-        return False
-
-    @property
-    def search_db_boost(self):
-        warnings.warn(
-            (
-                "This attribute of CoderedPageMeta has been deprecated in favor of"
-                " Wagtail's included search functionality."
-            ),
-            DeprecationWarning,
-        )
-        return 0
 
 
 class CoderedTag(TaggedItemBase):

--- a/coderedcms/templates/coderedcms/pages/search.html
+++ b/coderedcms/templates/coderedcms/pages/search.html
@@ -35,25 +35,25 @@
         </form>
         {% endif %}
 
-        {% if pagetypes %}
         {% block search_page_types %}
-          {% query_update request.GET 'p' None as qs_nop %}
-          <div class="mt-5">
-            <ul class="nav nav-pills">
-              <li class="nav-item">
-                {% query_update qs_nop 't' None as qs_t %}
-                <a class="nav-link {% if not form.t.value %}active{% endif %}" href="?{{qs_t.urlencode}}">{% trans 'All Results' %}</a>
-              </li>
-              {% for pt in pagetypes %}
-              <li class="nav-item">
-                {% query_update qs_nop 't' pt.content_type.model as qs_t %}
-                <a class="nav-link {% if form.t.value == pt.content_type.model %}active{% endif %}" href="?{{qs_t.urlencode}}">{{pt|get_plural_name_of_class}}</a>
-              </li>
-              {% endfor %}
-            </ul>
-          </div>
+          {% if pagetypes %}
+            {% query_update request.GET 'p' None as qs_nop %}
+            <div class="mt-5">
+              <ul class="nav nav-pills">
+                <li class="nav-item">
+                  {% query_update qs_nop 't' None as qs_t %}
+                  <a class="nav-link {% if not form.t.value %}active{% endif %}" href="?{{qs_t.urlencode}}">{% trans 'All Results' %}</a>
+                </li>
+                {% for pt in pagetypes %}
+                <li class="nav-item">
+                  {% query_update qs_nop 't' pt.content_type.model as qs_t %}
+                  <a class="nav-link {% if form.t.value == pt.content_type.model %}active{% endif %}" href="?{{qs_t.urlencode}}">{{pt|get_plural_name_of_class}}</a>
+                </li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
         {% endblock search_page_types %}
-        {% endif %}
 
         <hr class="mb-5">
 

--- a/coderedcms/templates/coderedcms/pages/search.html
+++ b/coderedcms/templates/coderedcms/pages/search.html
@@ -36,21 +36,23 @@
         {% endif %}
 
         {% if pagetypes %}
-        {% query_update request.GET 'p' None as qs_nop %}
-        <div class="mt-5">
+        {% block search_page_types %}
+          {% query_update request.GET 'p' None as qs_nop %}
+          <div class="mt-5">
             <ul class="nav nav-pills">
-                <li class="nav-item">
-                    {% query_update qs_nop 't' None as qs_t %}
-                    <a class="nav-link {% if not form.t.value %}active{% endif %}" href="?{{qs_t.urlencode}}">{% trans 'All Results' %}</a>
-                </li>
-                {% for pt in pagetypes %}
-                <li class="nav-item">
-                    {% query_update qs_nop 't' pt.content_type.model as qs_t %}
-                    <a class="nav-link {% if form.t.value == pt.content_type.model %}active{% endif %}" href="?{{qs_t.urlencode}}">{{pt|get_name_of_class}}</a>
-                </li>
-                {% endfor %}
+              <li class="nav-item">
+                {% query_update qs_nop 't' None as qs_t %}
+                <a class="nav-link {% if not form.t.value %}active{% endif %}" href="?{{qs_t.urlencode}}">{% trans 'All Results' %}</a>
+              </li>
+              {% for pt in pagetypes %}
+              <li class="nav-item">
+                {% query_update qs_nop 't' pt.content_type.model as qs_t %}
+                <a class="nav-link {% if form.t.value == pt.content_type.model %}active{% endif %}" href="?{{qs_t.urlencode}}">{{pt|get_plural_name_of_class}}</a>
+              </li>
+              {% endfor %}
             </ul>
-        </div>
+          </div>
+        {% endblock search_page_types %}
         {% endif %}
 
         <hr class="mb-5">

--- a/coderedcms/templates/coderedcms/pages/search.html
+++ b/coderedcms/templates/coderedcms/pages/search.html
@@ -5,6 +5,7 @@
 
 {% block extra_head %}
 <title>{% if not form.s.value %}{% trans 'Search' %}{% else %}{% trans 'Search for' %} “{{form.s.value}}”{% endif %} — {{ site.site_name }}</title>
+{{ block.super }}
 {% endblock %}
 
 {% block content_pre_body %}

--- a/coderedcms/templates/coderedcms/pages/search.html
+++ b/coderedcms/templates/coderedcms/pages/search.html
@@ -1,80 +1,87 @@
-{% extends "coderedcms/pages/web_page.html" %}
-{% load bootstrap4 i18n coderedcms_tags %}
+{% extends "coderedcms/pages/web_page_notitle.html" %}
+{% load bootstrap4 i18n coderedcms_tags wagtailcore_tags %}
 
-{% block title %}
-    {% if not form.s.value %}
-        {% trans 'Search' %}
-    {% else %}
-        {% trans 'Search for' %} “{{form.s.value}}”
-    {%endif%}
+{% wagtail_site as site %}
+
+{% block extra_head %}
+<title>{% if not form.s.value %}{% trans 'Search' %}{% else %}{% trans 'Search for' %} “{{form.s.value}}”{% endif %} — {{ site.site_name }}</title>
 {% endblock %}
 
-{% block content %}
-    <div class="container">
+{% block content_pre_body %}
+<div class="container my-5">
+  {% if not form.s.value %}
+  <h1>{% trans 'Search' %}</h1>
+  {% else %}
+  <h1>{% trans 'Search for' %} “{{form.s.value}}”</h1>
+  {% endif %}
+</div>
+{% endblock %}
 
-        <div class="mt-5">
-          {% if not form.s.value %}
-              <h2>{% trans 'Search' %}</h2>
-          {% else %}
-              <h2>{% trans 'Search for' %} “{{form.s.value}}”</h2>
-          {%endif%}
+{% block content_body %}
+<div class="container">
+  {% block search_form %}
+  {% if not settings.coderedcms.LayoutSettings.navbar_search %}
+  <form class="mt-5" action="{% url 'codered_search' %}" method="GET">
+    <div class="row">
+      <div class="col-sm-9">
+        {% bootstrap_form form size='large' layout='inline' %}
+      </div>
+      <div class="col-sm-3">
+        <div class="form-group">
+          <button class="btn btn-lg btn-block btn-outline-primary" type="submit">{% trans 'Search' %}</button>
         </div>
-
-        {% if not settings.coderedcms.LayoutSettings.navbar_search %}
-        <form class="mt-5" action="{% url 'codered_search' %}" method="GET">
-            <div class="row">
-                <div class="col-sm-9">
-                    {% bootstrap_form form size='large' layout='inline' %}
-                </div>
-                <div class="col-sm-3">
-                    <div class="form-group">
-                        <button class="btn btn-lg btn-block btn-outline-primary" type="submit">{% trans 'Search' %}</button>
-                    </div>
-                </div>
-            </div>
-        </form>
-        {% endif %}
-
-        {% block search_page_types %}
-          {% if pagetypes %}
-            {% query_update request.GET 'p' None as qs_nop %}
-            <div class="mt-5">
-              <ul class="nav nav-pills">
-                <li class="nav-item">
-                  {% query_update qs_nop 't' None as qs_t %}
-                  <a class="nav-link {% if not form.t.value %}active{% endif %}" href="?{{qs_t.urlencode}}">{% trans 'All Results' %}</a>
-                </li>
-                {% for pt in pagetypes %}
-                <li class="nav-item">
-                  {% query_update qs_nop 't' pt.content_type.model as qs_t %}
-                  <a class="nav-link {% if form.t.value == pt.content_type.model %}active{% endif %}" href="?{{qs_t.urlencode}}">{{pt|get_plural_name_of_class}}</a>
-                </li>
-                {% endfor %}
-              </ul>
-            </div>
-          {% endif %}
-        {% endblock search_page_types %}
-
-        <hr class="mb-5">
-
-
-        {% if results_paginated.object_list %}
-            {% for page in results_paginated %}
-            <div class="mb-5">
-                {% with page=page.specific %}
-                    {% if page.search_template %}
-                      {% include page.search_template %}
-                    {% else %}
-                      {% include 'coderedcms/pages/search_result.html' %}
-                    {% endif %}
-                {% endwith %}
-            </div>
-            {% endfor %}
-            {% include "coderedcms/includes/pagination.html" with items=results_paginated %}
-        {% else %}
-            {% if form.s.value %}
-              <p>{% trans 'No results found.' %}</p>
-            {% endif %}
-        {% endif %}
+      </div>
     </div>
+  </form>
+  {% endif %}
+  {% endblock search_form %}
+
+  {% block search_page_types %}
+  {% if pagetypes %}
+  {% query_update request.GET 'p' None as qs_nop %}
+  <div class="mt-5">
+    <ul class="nav nav-pills">
+      <li class="nav-item">
+        {% query_update qs_nop 't' None as qs_t %}
+        <a class="nav-link {% if not form.t.value %}active{% endif %}" href="?{{qs_t.urlencode}}">{% trans 'All Results' %}</a>
+      </li>
+      {% for pt in pagetypes %}
+      <li class="nav-item">
+        {% query_update qs_nop 't' pt.content_type.model as qs_t %}
+        <a class="nav-link {% if form.t.value == pt.content_type.model %}active{% endif %}" href="?{{qs_t.urlencode}}">{{pt|get_plural_name_of_class}}</a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+  {% endblock search_page_types %}
+
+  <hr class="mb-5">
+
+  {% if results_paginated.object_list %}
+
+  {% block search_results %}
+  {% for page in results_paginated %}
+  <div class="mb-5">
+    {% with page=page.specific %}
+    {% if page.search_template %}
+    {% include page.search_template %}
+    {% else %}
+    {% include 'coderedcms/pages/search_result.html' %}
+    {% endif %}
+    {% endwith %}
+  </div>
+  {% endfor %}
+  {% include "coderedcms/includes/pagination.html" with items=results_paginated %}
+  {% endblock search_results %}
+
+  {% elif form.s.value %}
+
+  {% block search_noresults %}
+  <p>{% trans 'No results found.' %}</p>
+  {% endblock search_noresults %}
+
+  {% endif %}
+
+</div>
 {% endblock %}

--- a/coderedcms/templates/coderedcms/pages/search.html
+++ b/coderedcms/templates/coderedcms/pages/search.html
@@ -46,7 +46,7 @@
                 {% for pt in pagetypes %}
                 <li class="nav-item">
                     {% query_update qs_nop 't' pt.content_type.model as qs_t %}
-                    <a class="nav-link {% if form.t.value == pt.content_type.model %}active{% endif %}" href="?{{qs_t.urlencode}}">{{pt.search_name_plural}}</a>
+                    <a class="nav-link {% if form.t.value == pt.content_type.model %}active{% endif %}" href="?{{qs_t.urlencode}}">{{pt|get_name_of_class}}</a>
                 </li>
                 {% endfor %}
             </ul>
@@ -60,7 +60,11 @@
             {% for page in results_paginated %}
             <div class="mb-5">
                 {% with page=page.specific %}
-                    {% include page.search_template %}
+                    {% if page.search_template %}
+                      {% include page.search_template %}
+                    {% else %}
+                      {% include 'coderedcms/pages/search_result.html' %}
+                    {% endif %}
                 {% endwith %}
             </div>
             {% endfor %}

--- a/coderedcms/templates/coderedcms/pages/search_result.html
+++ b/coderedcms/templates/coderedcms/pages/search_result.html
@@ -1,6 +1,8 @@
+{% load coderedcms_tags %}
+
 <div class="d-flex align-items-center">
     <h4><a href="{{page.url}}">{{page.title}}</a></h4>
-    {% if page.content_type.model_class in pagetypes %}<small class="ml-3 badge badge-secondary">{{page.search_name}}</small>{% endif %}
+    {% if page.content_type.model_class in pagetypes %}<small class="ml-3 badge badge-secondary">{{page|get_name_of_class}}</small>{% endif %}
 </div>
 {% if page.search_description %}
     <p>{{page.search_description|safe}}</p>

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -188,8 +188,8 @@ def map_to_bootstrap_alert(message_tag):
 
 @register.filter
 def get_name_of_class(class_type):
-    if hasattr(class_type.__class__, "search_name_plural"):
-        return class_type.__class__.search_name_plural
+    if hasattr(class_type.__class__, "search_name"):
+        return class_type.__class__.search_name
     elif (
             hasattr(class_type.__class__, "_meta") and
             hasattr(class_type.__class__._meta, "verbose_name")
@@ -197,3 +197,16 @@ def get_name_of_class(class_type):
         return class_type.__class__._meta.verbose_name
     else:
         return class_type.__class__.__name__
+
+
+@register.filter
+def get_plural_name_of_class(class_type):
+    if hasattr(class_type.__class__, "search_name_plural"):
+        return class_type.__class__.search_name_plural
+    elif (
+            hasattr(class_type.__class__, "_meta") and
+            hasattr(class_type.__class__._meta, "verbose_name_plural")
+    ):
+        return class_type.__class__._meta.verbose_name_plural
+    else:
+        return class_type.__class__.__name__ + "s"

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -188,4 +188,12 @@ def map_to_bootstrap_alert(message_tag):
 
 @register.filter
 def get_name_of_class(class_type):
-    return class_type.__class__.__name__
+    if hasattr(class_type.__class__, "search_name_plural"):
+        return class_type.__class__.search_name_plural
+    elif (
+            hasattr(class_type.__class__, "_meta") and
+            hasattr(class_type.__class__._meta, "verbose_name")
+    ):
+        return class_type.__class__._meta.verbose_name
+    else:
+        return class_type.__class__.__name__

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -184,3 +184,8 @@ def map_to_bootstrap_alert(message_tag):
         return message_to_alert_dict[message_tag]
     except KeyError:
         return ''
+
+
+@register.filter
+def get_name_of_class(class_type):
+    return class_type.__class__.__name__

--- a/coderedcms/views.py
+++ b/coderedcms/views.py
@@ -21,6 +21,7 @@ from coderedcms.models import (
 )
 from coderedcms.importexport import convert_csv_to_json, import_pages, ImportPagesFromCSVFileForm
 from coderedcms.settings import crx_settings
+from coderedcms.templatetags.coderedcms_tags import get_name_of_class
 
 
 def search(request):
@@ -37,19 +38,10 @@ def search(request):
         search_model = search_form.cleaned_data['t']
 
         # get all page models
-        pagemodels = sorted(get_page_models(), key=lambda k: k.__name__)
-        # If any types have the search_filterable flag set, only show those
-        # else, show all
-        filter_types = False
+        pagemodels = sorted(get_page_models(), key=get_name_of_class)
+        # filter based on is search_filterable
         for model in pagemodels:
             if hasattr(model, "search_filterable") and model.search_filterable:
-                if not filter_types:
-                    filter_types = True
-                    # if we turn out to be using search_filterable, reset our list
-                    pagetypes = []
-                pagetypes.append(model)
-
-            if not filter_types:
                 pagetypes.append(model)
 
         results = Page.objects.live()

--- a/docs/features/searching.rst
+++ b/docs/features/searching.rst
@@ -14,19 +14,21 @@ The template can be overridden per model with the ``search_template`` attribute.
 
 Search result filtering
 -----------------------
-By default, search results can be filtered by the page type to allow for a more specific search.
 
-
-To all filtering only by specific page types, add ``search_filterable = True`` to the page model.
-The ``verbose_name`` and ``verbose_name_plural`` fields are then used to display the labels for
-these filters.
-For example, to specify search filtering only by Blog or by Products in addition to All Results::
+To enable additional filtering by page type, add ``search_filterable = True`` to the page model.
+The ``search_name`` and ``search_name_plural`` fields are then used to display the labels for
+these filters (defaults to ``verbose_name`` and ``verbose_name_plural`` if not specified).
+For example, to enable search filtering by Blog or by Products in addition to All Results::
 
     class BlogPage(CoderedArticlePage):
         search_filterable = True
+        search_name = 'Blog Post'
+        search_name_plural = 'Blog'
 
     class Product(CoderedWebPage):
         search_filterable = True
+        search_name = 'Product'
+        search_name_plural = 'Products'
 
 Would enable the following filter options on the search page: All Results, Blog, Products.
 
@@ -34,7 +36,7 @@ Would enable the following filter options on the search page: All Results, Blog,
 Search fields
 -------------
 
-**Deprecated in 0.25, instead the Wagtail search parameters should be used. https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html#module-wagtail.contrib.search_promotions**
+.. deprecated:: 0.25, instead the `Wagtail search parameters<https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html#module-wagtail.contrib.search_promotions>`_ should be used.
 
 If using the Wagtail DatabaseSearch backend (default), only page Title and Search Description
 fields are searched upon. This is due to a limitation in the DatabaseSearch backend;

--- a/docs/features/searching.rst
+++ b/docs/features/searching.rst
@@ -37,9 +37,11 @@ Search fields
 -------------
 
 .. deprecated:: 0.25
-    Use the `Wagtail search parameters <https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html#module-wagtail.contrib.search_promotions>`_ instead.
 
-If using the Wagtail DatabaseSearch backend (default), only page Title and Search Description
+   The following behavior and the ``search_db_*`` options were removed in 0.25.
+   Use the `Wagtail search parameters <https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html#module-wagtail.contrib.search_promotions>`_ instead.
+
+If using the ``wagtail.search.backends.db`` backend (removed in Wagtail 3.0), only page Title and Search Description
 fields are searched upon. This is due to a limitation in the DatabaseSearch backend;
 other backends such as PostgreSQL and Elasticsearch will search on additional specific fields
 such as body, article captions, etc. To enable more specific searching while still using the

--- a/docs/features/searching.rst
+++ b/docs/features/searching.rst
@@ -14,53 +14,18 @@ The template can be overridden per model with the ``search_template`` attribute.
 
 Search result filtering
 -----------------------
+By default, search results can be filtered by the page type to allow for a more specific search.
 
-To enable additional filtering by page type, add ``search_filterable = True`` to the page model.
-The ``search_name`` and ``search_name_plural`` fields are then used to display the labels for
-these filters (defaults to ``verbose_name`` and ``verbose_name_plural`` if not specified).
-For example, to enable search filtering by Blog or by Products in addition to All Results::
+
+To all filtering only by specific page types, add ``search_filterable = True`` to the page model.
+The ``verbose_name`` and ``verbose_name_plural`` fields are then used to display the labels for
+these filters.
+For example, to specify search filtering only by Blog or by Products in addition to All Results::
 
     class BlogPage(CoderedArticlePage):
         search_filterable = True
-        search_name = 'Blog Post'
-        search_name_plural = 'Blog'
 
     class Product(CoderedWebPage):
         search_filterable = True
-        search_name = 'Product'
-        search_name_plural = 'Products'
 
 Would enable the following filter options on the search page: All Results, Blog, Products.
-
-Search fields
--------------
-
-If using the Wagtail DatabaseSearch backend (default), only page Title and Search Description
-fields are searched upon. This is due to a limitation in the DatabaseSearch backend;
-other backends such as PostgreSQL and Elasticsearch will search on additional specific fields
-such as body, article captions, etc. To enable more specific searching while still using the
-database backend, the specific models can be flagged for inclusion in search by setting
-``search_db_include = True`` on the page model. Note that this must be set on every type of page
-model you wish to include in search. When setting this flag, search is performed independently on
-each page type, and the results are combined. So you may want to also specify ``search_db_boost`` (int)
-to control the order in which the pages are searched. Pages with a higher ``search_db_boost``
-are searched first, and results are shown higher in the list. For example::
-
-    class Article(CoderedArticlePage):
-        search_db_include = True
-        search_db_boost = 10
-        ...
-
-    class WebPage(CoderedWebPage):
-        search_db_include = True
-        search_db_boost = 9
-        ...
-
-    class FormPage(CoderedFormPage):
-        ...
-
-In this example, Article search results will be shown before WebPage results when using the
-DatabaseSearch backend. FormPage results will not be shown at all, due to the absence
-``search_db_include``. If no models have ``search_db_include = True``, All CoderedPages
-will be searched by title and description. When using any search backend other than database,
-``search_db_*`` variables are ignored.

--- a/docs/features/searching.rst
+++ b/docs/features/searching.rst
@@ -36,7 +36,8 @@ Would enable the following filter options on the search page: All Results, Blog,
 Search fields
 -------------
 
-.. deprecated:: 0.25, instead the `Wagtail search parameters <https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html#module-wagtail.contrib.search_promotions>`_ should be used.
+.. deprecated:: 0.25
+    Use the `Wagtail search parameters <https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html#module-wagtail.contrib.search_promotions>`_ instead.
 
 If using the Wagtail DatabaseSearch backend (default), only page Title and Search Description
 fields are searched upon. This is due to a limitation in the DatabaseSearch backend;

--- a/docs/features/searching.rst
+++ b/docs/features/searching.rst
@@ -36,7 +36,7 @@ Would enable the following filter options on the search page: All Results, Blog,
 Search fields
 -------------
 
-.. deprecated:: 0.25, instead the `Wagtail search parameters<https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html#module-wagtail.contrib.search_promotions>`_ should be used.
+.. deprecated:: 0.25, instead the `Wagtail search parameters <https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html#module-wagtail.contrib.search_promotions>`_ should be used.
 
 If using the Wagtail DatabaseSearch backend (default), only page Title and Search Description
 fields are searched upon. This is due to a limitation in the DatabaseSearch backend;

--- a/docs/features/searching.rst
+++ b/docs/features/searching.rst
@@ -29,3 +29,39 @@ For example, to specify search filtering only by Blog or by Products in addition
         search_filterable = True
 
 Would enable the following filter options on the search page: All Results, Blog, Products.
+
+
+Search fields
+-------------
+
+**Deprecated in 0.25, instead the Wagtail search parameters should be used. https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html#module-wagtail.contrib.search_promotions**
+
+If using the Wagtail DatabaseSearch backend (default), only page Title and Search Description
+fields are searched upon. This is due to a limitation in the DatabaseSearch backend;
+other backends such as PostgreSQL and Elasticsearch will search on additional specific fields
+such as body, article captions, etc. To enable more specific searching while still using the
+database backend, the specific models can be flagged for inclusion in search by setting
+``search_db_include = True`` on the page model. Note that this must be set on every type of page
+model you wish to include in search. When setting this flag, search is performed independently on
+each page type, and the results are combined. So you may want to also specify ``search_db_boost`` (int)
+to control the order in which the pages are searched. Pages with a higher ``search_db_boost``
+are searched first, and results are shown higher in the list. For example::
+
+    class Article(CoderedArticlePage):
+        search_db_include = True
+        search_db_boost = 10
+        ...
+
+    class WebPage(CoderedWebPage):
+        search_db_include = True
+        search_db_boost = 9
+        ...
+
+    class FormPage(CoderedFormPage):
+        ...
+
+In this example, Article search results will be shown before WebPage results when using the
+DatabaseSearch backend. FormPage results will not be shown at all, due to the absence
+``search_db_include``. If no models have ``search_db_include = True``, All CoderedPages
+will be searched by title and description. When using any search backend other than database,
+``search_db_*`` variables are ignored.


### PR DESCRIPTION
#### Description of change
In Wagtail 2.16, they overhauled the search functionality to be able to properly search multiple different Page types. We had implemented this feature in a work around method locally in CRX, which is no longer necessary.

Fixes #82 

This change:
1. Removes the workaround to use Wagtail's search directly.
2. Maintains existing legacy behavior for page type filtering, but also allows filtering of non-CRX page types.
3. Deprecates several attributes from CRX Page models that are no longer necessary

#### Documentation
Updated search documentation to be in line with new functionality/deprecation.

#### Tests
A unit test for the search endpoint already exists, this cod change was made in line with it.
