### PR TITLE
Hotfix timezones on ics export

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -105,6 +105,7 @@ CODERED_PAGE_MODELS = []
 def get_page_models():
     return CODERED_PAGE_MODELS
 
+
 class CoderedPageMeta(PageBase):
     def __init__(cls, name, bases, dct):
         super().__init__(name, bases, dct)

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -8,6 +8,8 @@ import os
 import warnings
 from datetime import date, datetime
 from typing import Dict, List, Optional, TYPE_CHECKING, Union
+# This is a requirement for icalendar, even if django doesn't require it
+import pytz
 
 import geocoder
 from django import forms
@@ -102,7 +104,6 @@ CODERED_PAGE_MODELS = []
 
 def get_page_models():
     return CODERED_PAGE_MODELS
-
 
 class CoderedPageMeta(PageBase):
     def __init__(cls, name, bases, dct):
@@ -840,7 +841,12 @@ class CoderedEventPage(CoderedWebPage, BaseEvent):
         # Return the event instances, possibly spliced if num_instances_to_return is set.
         return event_instances[:num_of_instances_to_return] if num_of_instances_to_return else event_instances  # noqa
 
-    def convert_to_ical_format(self, dt_start=None, dt_end=None, occurrence=None):
+    def convert_to_ical_format(
+        self,
+        dt_start: datetime = None,
+        dt_end: datetime = None,
+        occurrence=None,
+    ):
         ical_event = ICalEvent()
         ical_event.add('summary', self.title)
         # needs to get full page url, not just slug
@@ -858,12 +864,12 @@ class CoderedEventPage(CoderedWebPage, BaseEvent):
 
         if dt_start:
             # Convert to utc to remove timezone confusion
-            dt_start = dt_start.astimezone(timezone.utc)
+            dt_start = dt_start.astimezone(pytz.utc)
             ical_event.add('dtstart', dt_start)
 
             if dt_end:
                 # Convert to utc to remove timezone confusion
-                dt_end = dt_end.astimezone(timezone.utc)
+                dt_end = dt_end.astimezone(pytz.utc)
                 ical_event.add('dtend', dt_end)
 
             # Add a reminder alarm

--- a/docs/releases/v0.25.1.rst
+++ b/docs/releases/v0.25.1.rst
@@ -6,7 +6,7 @@ Bug fixes
 ---------
 
 * Correct generation of .ics files to be consistent with the iCal format, fixing
-  compatability with Outlook for Mac and other highly compliant software.
+  compatibility with Outlook for Mac and other highly compliant software.
 
 
 Thank you!

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'django-bootstrap4==22.1',
         'Django>=3.2,<4.1',             # should be the same as wagtail
         'geocoder==1.38.*',
-        'icalendar==4.0.*',
+        'icalendar==4.1.*',
         'wagtail==2.16.*',
         'wagtail-cache==1.*',
         'wagtail-seo==1.*',


### PR DESCRIPTION
#### Description of change
In version 0.25.1, a fix was introduced which improved the compliance of the .ics exports of EventOccurrences. In an attempt to remove as many dependencies as possible, this change used python's builtin `timezone.utc` instead of `pytz.utc` as the timezone for `dtstart` and `dtend`. 

Unfortunately, the iCalendar package is built around using `pytz`, and throws out non compliant output when not using pytz. 

This reverts the change to using pytz, with the understanding that it will be removed when the iCalendar package is also removed.

#### Tests
This was tested manually by exporting an event to .ics and validating it with: https://icalendar.org/validator.html#results
