### PR TITLE
Clean up HTML cruft

### DIFF
--- a/coderedcms/project_template/basic/website/templates/coderedcms/pages/base.html
+++ b/coderedcms/project_template/basic/website/templates/coderedcms/pages/base.html
@@ -3,10 +3,10 @@
 
 {% block custom_assets %}
 {# Add your custom CSS here #}
-<link rel="stylesheet" type="text/css" href="{% static 'website/css/custom.css' %}">
+<link rel="stylesheet" href="{% static 'website/css/custom.css' %}">
 {% endblock %}
 
 {% block custom_scripts %}
 {# Add your custom JavaScript here, or delete the line below if you don't need any #}
-<script type="text/javascript" src="{% static 'website/js/custom.js' %}"></script>
+<script src="{% static 'website/js/custom.js' %}"></script>
 {% endblock %}

--- a/coderedcms/project_template/sass/website/templates/coderedcms/pages/base.html
+++ b/coderedcms/project_template/sass/website/templates/coderedcms/pages/base.html
@@ -11,15 +11,15 @@
 
 {% block custom_assets %}
 {# Add your custom CSS here #}
-<link rel="stylesheet" type="text/css" href="{% static 'website/css/custom.css' %}">
+<link rel="stylesheet" href="{% static 'website/css/custom.css' %}">
 {% endblock %}
 
 {% block frontend_scripts %}
-{# Load Bootstrap scripts distributed by coderedcms #}
-<script src="{% static 'coderedcms/vendor/bootstrap/dist/js/bootstrap.min.js' %}"></script>
+{# Load Bootstrap scripts distributed by coderedcms, or use your own as needed #}
+<script src="{% static 'coderedcms/vendor/bootstrap/dist/js/bootstrap.bundle.min.js' %}"></script>
 {% endblock %}
 
 {% block custom_scripts %}
 {# Add your custom JavaScript here, or delete the line below if you don't need any #}
-<script type="text/javascript" src="{% static 'website/js/custom.js' %}"></script>
+<script src="{% static 'website/js/custom.js' %}"></script>
 {% endblock %}

--- a/coderedcms/templates/500.html
+++ b/coderedcms/templates/500.html
@@ -2,9 +2,9 @@
 <html>
 
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <title>Internal server error</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body {
       font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;

--- a/coderedcms/templates/coderedcms/blocks/base_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/base_link_block.html
@@ -11,7 +11,7 @@
     {% if ga_event_category %}data-ga-event-category="{{ ga_event_category }}"{% endif %}>
     {% if value.image %}
     {% image value.image max-256x256 format-webp as img %}
-    <img src="{{img.url}}" class="w-100" alt="{{img.image.title}}" />
+    <img src="{{img.url}}" class="w-100" alt="{{img.image.title}}">
     {% elif value.display_text %}
     {{value.display_text|safe}}
     {% elif value.page %}

--- a/coderedcms/templates/coderedcms/blocks/carousel_block.html
+++ b/coderedcms/templates/coderedcms/blocks/carousel_block.html
@@ -19,7 +19,7 @@
       {% block carousel_slide_image %}
       {% if item.image %}
       {% image item.image fill-1600x900 format-webp as carouselimage %}
-      <img class="d-block w-100" src="{{carouselimage.url}}" alt="{{carouselimage.image.title}}" />
+      <img class="d-block w-100" src="{{carouselimage.url}}" alt="{{carouselimage.image.title}}">
       {% endif %}
       {% endblock %}
       <div class="carousel-caption d-none d-md-block">

--- a/coderedcms/templates/coderedcms/blocks/image_gallery_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_gallery_block.html
@@ -9,7 +9,7 @@
     <div class="col-sm-6 col-md-4 col-lg-3 my-3">
       <a href="#" class="lightbox-preview" data-bs-toggle="modal" data-bs-target="#modal-{{modal_id}}">
         <img class="img-thumbnail w-100" src="{{picture_image.url}}" data-original-src="{{original_image.url}}"
-          alt="{{picture_image.image.title}}" title="{{picture_image.image.title}}" />
+          alt="{{picture_image.image.title}}" title="{{picture_image.image.title}}">
       </a>
     </div>
     {% endfor %}
@@ -18,7 +18,7 @@
     aria-hidden="true">
     <div class="modal-dialog modal-lightbox">
       <div class="modal-body">
-        <img src="" class="img-fluid" alt="" />
+        <img src="" class="img-fluid" alt="">
       </div>
     </div>
   </div>

--- a/coderedcms/templates/coderedcms/includes/ical/calendar_ical_button.html
+++ b/coderedcms/templates/coderedcms/includes/ical/calendar_ical_button.html
@@ -1,5 +1,5 @@
 <form class="calendar-ical-form" action="{% url 'event_generate_ical_for_calendar' %}" method="POST">
-  <input name="page_id" type="number" hidden value="{{ page.id }}" />
+  <input name="page_id" type="number" hidden value="{{ page.id }}">
   {% csrf_token %}
   <button class="btn btn-primary" title="Download calendar in .ics format" type="submit">
     {% block button_text %}Download Calendar (ical){% endblock %}

--- a/coderedcms/templates/coderedcms/includes/ical/recurring_ical_button.html
+++ b/coderedcms/templates/coderedcms/includes/ical/recurring_ical_button.html
@@ -1,5 +1,5 @@
 <form data-attribute="recurring-ical-form-{{event.pk}}" class="recurring-ical-form" action="{% url 'event_generate_recurring_ical' %}" method="POST">
   {% csrf_token %}
-  <input name="event_pk" type="number" hidden value="{{event.pk}}" />
+  <input name="event_pk" type="number" hidden value="{{event.pk}}">
   <button class="btn btn-primary" title="Download events in .ical format" type="submit">{% block button_text %}Add All Events To Calendar{% endblock %}</button>
 </form>

--- a/coderedcms/templates/coderedcms/includes/ical/single_ical_button.html
+++ b/coderedcms/templates/coderedcms/includes/ical/single_ical_button.html
@@ -1,7 +1,7 @@
 <form data-attribute="single-ical-form-{{event.pk}}-{{datetime_start}}" class="single-ical-form d-inline" action="{% url 'event_generate_single_ical' %}" method="POST">
   {% csrf_token %}
-  <input name="event_pk" type="number" hidden value="{{event.pk}}" />
-  <input name="datetime_start" type="text" hidden value="{{start|date:"c"}}" />
-  <input name="datetime_end" type="text" hidden value="{{end|date:"c"}}" />
+  <input name="event_pk" type="number" hidden value="{{event.pk}}">
+  <input name="datetime_start" type="text" hidden value="{{start|date:"c"}}">
+  <input name="datetime_end" type="text" hidden value="{{end|date:"c"}}">
   <button class="btn btn-primary" title="Download event in .ical format" type="submit">{% block button_text %}Add to Calendar{% endblock %}</button>
 </form>

--- a/coderedcms/templates/coderedcms/includes/map_list_description.html
+++ b/coderedcms/templates/coderedcms/includes/map_list_description.html
@@ -4,7 +4,7 @@
   </div>
   <small>{{ page.address }}</small>
   {% if description %}
-  <br />
+  <br>
   <small>{{ page.description }}</small>
   {% endif %}
 </div>

--- a/coderedcms/templates/coderedcms/pages/article_index_page.html
+++ b/coderedcms/templates/coderedcms/pages/article_index_page.html
@@ -11,7 +11,7 @@
       <a href="{% pageurl article %}" title="{{article.title}}" class="text-white-50">
         {% if article.cover_image %}
         {% image article.specific.cover_image fill-1600x900 format-webp as cover_image %}
-        <img src="{{cover_image.url}}" class="w-100" alt="{{article.title}}" />
+        <img src="{{cover_image.url}}" class="w-100" alt="{{article.title}}">
         {% endif %}
       </a>
       {% endif %}

--- a/coderedcms/templates/coderedcms/pages/article_page.html
+++ b/coderedcms/templates/coderedcms/pages/article_page.html
@@ -26,7 +26,7 @@
   {% if self.cover_image %}
   <div class="container mb-5">
     {% image self.cover_image fill-1600x900 format-webp as cover_image %}
-    <img src="{{cover_image.url}}" class="w-100" />
+    <img src="{{cover_image.url}}" class="w-100">
   </div>
   {% endif %}
   {% endblock %}

--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -65,15 +65,13 @@
 
   {% block coderedcms_assets %}
   {% if "DEBUG"|django_settings %}
-  <link rel="stylesheet" type="text/css" href="{% static 'coderedcms/css/crx-front.css' %}?v={% coderedcms_version %}">
+  <link rel="stylesheet" href="{% static 'coderedcms/css/crx-front.css' %}?v={% coderedcms_version %}">
   {% else %}
-  <link rel="stylesheet" type="text/css" href="{% static 'coderedcms/css/crx-front.min.css' %}?v={% coderedcms_version %}">
+  <link rel="stylesheet" href="{% static 'coderedcms/css/crx-front.min.css' %}?v={% coderedcms_version %}">
   {% endif %}
   {% endblock %}
 
-  {% block custom_assets %}
-  <link rel="stylesheet" type="text/css" href="{% static 'css/custom.css' %}">
-  {% endblock %}
+  {% block custom_assets %}{% endblock %}
 
   {% block favicon %}
   {% if settings.coderedcms.LayoutSettings.favicon %}
@@ -162,7 +160,7 @@
   {% endblock %}
 
   {% block coderedcms_scripts %}
-  <script type="text/javascript" src="{% static 'coderedcms/js/crx-front.js' %}?v={% coderedcms_version %}"></script>
+  <script src="{% static 'coderedcms/js/crx-front.js' %}?v={% coderedcms_version %}"></script>
   {% endblock %}
 
   {% block custom_scripts %}{% endblock %}

--- a/coderedcms/templates/coderedcms/pages/base.html
+++ b/coderedcms/templates/coderedcms/pages/base.html
@@ -1,4 +1,4 @@
-{% load i18n static coderedcms_tags i18n wagtailcore_tags wagtailimages_tags wagtailsettings_tags wagtailuserbar %}
+{% load coderedcms_tags i18n static wagtailcore_tags wagtailimages_tags wagtailsettings_tags wagtailuserbar %}
 {% get_settings %}
 {% get_current_language as LANGUAGE_CODE %}
 {% wagtail_site as site %}
@@ -49,7 +49,7 @@
     cr_version = "{% coderedcms_version %}";
   </script>
 
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   {# SEO Metadata #}
@@ -57,9 +57,9 @@
 
   {% block frontend_assets %}
   {% if settings.coderedcms.LayoutSettings.frontend_theme %}
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.2.0/{{settings.coderedcms.LayoutSettings.frontend_theme}}/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.2.0/{{settings.coderedcms.LayoutSettings.frontend_theme}}/bootstrap.min.css">
   {% else %}
-  <link rel="stylesheet" href="{% static 'coderedcms/vendor/bootstrap/dist/css/bootstrap.min.css' %}?v={% coderedcms_version %}" />
+  <link rel="stylesheet" href="{% static 'coderedcms/vendor/bootstrap/dist/css/bootstrap.min.css' %}?v={% coderedcms_version %}">
   {% endif %}
   {% endblock %}
 
@@ -83,7 +83,7 @@
   {% image settings.coderedcms.LayoutSettings.favicon fill-180x180 format-png as favicon_iphone_plus %}
   {% image settings.coderedcms.LayoutSettings.favicon fill-152x152 format-png as favicon_ipad %}
   {% image settings.coderedcms.LayoutSettings.favicon fill-167x167 format-png as favicon_ipad_pro %}
-  <link rel="icon" type="image/webp" href="{{ favicon_webp.url }}" />
+  <link rel="icon" type="image/webp" href="{{ favicon_webp.url }}">
   <link rel="apple-touch-icon" href="{{ favicon_iphone_plus.url }}">
   <link rel="apple-touch-icon" sizes="120x120" href="{{ favicon_iphone.url }}">
   <link rel="apple-touch-icon" sizes="180x180" href="{{ favicon_iphone_plus.url }}">
@@ -165,10 +165,7 @@
   <script type="text/javascript" src="{% static 'coderedcms/js/crx-front.js' %}?v={% coderedcms_version %}"></script>
   {% endblock %}
 
-  {% block custom_scripts %}
-  {# Legacy behavior, remove this in the future and leave blank for client sites to implement. #}
-  <script type="text/javascript" src="{% static 'js/custom.js' %}"></script>
-  {% endblock %}
+  {% block custom_scripts %}{% endblock %}
 
   {% include "wagtailseo/struct_data.html" %}
 

--- a/coderedcms/templates/coderedcms/pages/event_index_page.html
+++ b/coderedcms/templates/coderedcms/pages/event_index_page.html
@@ -24,7 +24,7 @@
     {% if event.cover_image %}
     <div class="col-md">
       {% image event.cover_image fill-1600x900 format-webp as cover_image %}
-      <a href="{{ event.url }}" title="{{ event.title }}"><img src="{{ cover_image.url }}" class="w-100" alt="{{ event.title }}" /></a>
+      <a href="{{ event.url }}" title="{{ event.title }}"><img src="{{ cover_image.url }}" class="w-100" alt="{{ event.title }}"></a>
     </div>
     {% endif %}
     {% endblock %}

--- a/coderedcms/templates/coderedcms/pages/stream_form_page.html
+++ b/coderedcms/templates/coderedcms/pages/stream_form_page.html
@@ -14,7 +14,7 @@
     </div>
     {% endwith %}
   </div>
-  <br />
+  <br>
   {% endif %}
   {% endblock %}
 

--- a/coderedcms/templates/coderedcms/snippets/navbar.html
+++ b/coderedcms/templates/coderedcms/snippets/navbar.html
@@ -5,7 +5,7 @@
     <a class="navbar-brand" href="/">
       {% if settings.coderedcms.LayoutSettings.logo %}
       {% image settings.coderedcms.LayoutSettings.logo original format-webp as logo %}
-      <img src="{{logo.url}}" alt="{{site.site_name}}" />
+      <img src="{{logo.url}}" alt="{{site.site_name}}">
       {% else %}
       {{site.site_name}}
       {% endif %}

--- a/coderedcms/templates/wagtailadmin/base.html
+++ b/coderedcms/templates/wagtailadmin/base.html
@@ -8,4 +8,4 @@
 
 {# NOTE: this must be on a single line, otherwise Django templates will create
   whitespace, and wagtail will think the whitespace is the custom logo! #}
-{% block branding_logo %}{% if settings.coderedcms.LayoutSettings.logo %}<div class="crx-logo-container {{settings.coderedcms.LayoutSettings.navbar_color_scheme}}">{% image settings.coderedcms.LayoutSettings.logo original format-webp as logo_image %}<img src="{{ logo_image.url }}" class="crx-logo-custom" alt="Dashboard"/></div>{% endif %}{% endblock %}
+{% block branding_logo %}{% if settings.coderedcms.LayoutSettings.logo %}<div class="crx-logo-container {{settings.coderedcms.LayoutSettings.navbar_color_scheme}}">{% image settings.coderedcms.LayoutSettings.logo original format-webp as logo_image %}<img src="{{ logo_image.url }}" class="crx-logo-custom" alt="Dashboard"></div>{% endif %}{% endblock %}


### PR DESCRIPTION
* Remove reference to `custom.css` and `custom.js` in `base.html`. They may not exist and were kept there for legacy reasons.
* Don't include optional trailing slash in self-closing HTML elements.
* Don't include optional `type` attribute in `<link>` and `<script>` tags.