### PR TITLE
Fix card grid deck layout

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/cardgrid_deck.html
+++ b/coderedcms/templates/coderedcms/blocks/cardgrid_deck.html
@@ -1,11 +1,8 @@
-{% extends "coderedcms/blocks/grid_block.html" %}
-{% load wagtailcore_tags %}
-{% block grid_content %}
+{% extends "coderedcms/blocks/grid_block.html" %} {% load wagtailcore_tags %} {%
+block grid_content %}
 <div class="row {{self.settings.custom_css_class}}">
-  <div class="col">
-    {% for block in self.content %}
-    {% include_block block %}
-    {% endfor %}
-  </div>
+  {% for block in self.content %}
+  <div class="col">{% include_block block %}</div>
+  {% endfor %}
 </div>
 {% endblock %}

--- a/coderedcms/templates/coderedcms/blocks/cardgrid_deck.html
+++ b/coderedcms/templates/coderedcms/blocks/cardgrid_deck.html
@@ -1,5 +1,6 @@
-{% extends "coderedcms/blocks/grid_block.html" %} {% load wagtailcore_tags %} {%
-block grid_content %}
+{% extends "coderedcms/blocks/grid_block.html" %}
+{% load wagtailcore_tags %}
+{% block grid_content %}
 <div class="row {{self.settings.custom_css_class}}">
   {% for block in self.content %}
   <div class="col">{% include_block block %}</div>


### PR DESCRIPTION
#### Description of change
I made a slight change to the template which should make cards display side by side.  
Currently cards were full width and under each other using this template.

It will now work like a responsive grid row making the cards equal widths.  

Fixes #537 