### PR TITLE
Fix StreamForm submissions

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1679,7 +1679,7 @@ class CoderedSessionFormSubmission(SessionFormSubmission):
         if "user" in submission_data:
             submission_data["user"] = str(submission_data["user"])
         submission = FormSubmission.objects.create(
-            form_data=json.dumps(submission_data, cls=StreamFormJSONEncoder),
+            form_data=submission_data,
             page=self.page,
         )
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -15,6 +15,7 @@ Wagtail CRX (previously CodeRed CMS) follows the
 .. toctree::
     :maxdepth: 1
 
+    v1.0.3
     v1.0.2
     v1.0.1
     v1.0.0

--- a/docs/releases/v1.0.3.rst
+++ b/docs/releases/v1.0.3.rst
@@ -1,0 +1,40 @@
+v1.0.3 release notes
+====================
+
+Bug fixes
+---------
+
+* Save stream form submissions in the correct format.
+
+Note: This bug was introduced in v1.0.0. If you were actively using ``CoderedStreamFormPage`` or ``CoderedStreamFormMixin`` (not the default configuration) with version 1.0.0, 1.0.1, or 1.0.2; and you are getting 500 errors when trying to view stream form submissions in the Wagtail admin, create a migration file with the following code or run it directly.
+
+.. code-block:: python
+
+   """
+   Wagtail 3.0 switched ``FormSubmission.form_data`` from
+   ``TextField`` to ``JSONField``. However, after the Wagtail 3 migration
+   ``CoderedStreamForm`` continued to treat it like a ``TextField`` and
+   manually dump stringified JSON into it. This migrations converts any
+   residual strings to JSON.
+   """
+
+   import json
+   from django.db import migrations
+   from website.models import YOUR_STREAMFORM_PAGE_MODEL as MyStreamFormPage
+
+   def destringify(apps, schema_editor):
+       for s in MyStreamFormPage.get_submission_class().objects.all():
+           if isinstance(s.form_data, str):
+               print(f"Fixing Submission {s.pk}")
+               s.form_data = json.loads(s.form_data)
+               s.save()
+
+   class Migration(migrations.Migration):
+
+       dependencies = [
+           ("coderedcms", "0035_remove_googleapisettings_site_and_more"),
+       ]
+
+       operations = [
+           migrations.RunPython(destringify),
+       ]


### PR DESCRIPTION
StreamForms have been broken in 1.x, however they are seldomly used. I noticed this after testing them with Wagtail 4, apparently, they were broken by Wagtail 3.

In the event that anyone was using StreamForms with 1.x, I have included a sample migration to fix the state of their database. However it is not being included with coderedcms, because I wouldn't want to blindly change `FormSubmission` objects (which is part of Wagtail, and used by other forms as well). There is also a chance the site is using a custom submission model, in which case the migration could not exist in coderedcms. If the site is experiencing an error caused by this bug, they should apply the migration themselves targeting the affected models.