### PR TITLE
Added closing figure tag to resolve issue #577.

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/quote_block.html
+++ b/coderedcms/templates/coderedcms/blocks/quote_block.html
@@ -6,4 +6,5 @@
 {% if self.author %}
 <figcaption class="blockquote-footer">{{self.author}}</figcaption>
 {% endif %}
+</figure>
 {% endblock %}


### PR DESCRIPTION
#### Description of change
Added a closing `</figure>` tag in `quote_block.html` to fix the HTML structure and resolve #577.

#### Documentation
N/A

#### Tests
This change was tested manually in the preview pane while editing a page. If you put a quote block above a text block and add the `text-center` CSS class to the quote block, you'll see the behavior.
