### PR TITLE
Added missing semicolons in film_strip_block template

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/film_strip_block.html
+++ b/coderedcms/templates/coderedcms/blocks/film_strip_block.html
@@ -9,8 +9,8 @@
         {% image panel.background_image original as image %}
         <div data-block="film-panel" class="col-auto col crx-filmstrip-panel {{panel.custom_css_class}}" {% if panel.custom_id %}id="{{panel.custom_id}}"{% endif %} style="
           {% if image %}background-image: url({{image.url}}); background-size: cover; background-position: center;{% endif %}
-          {% if panel.background_color %}background-color: {{panel.background_color}}{% endif %}
-          {% if panel.foreground_color %}color: {{panel.foreground_color}}{% endif %}
+          {% if panel.background_color %}background-color: {{panel.background_color}};{% endif %}
+          {% if panel.foreground_color %}color: {{panel.foreground_color}};{% endif %}
         ">
           {% include_block panel.content %}
         </div>


### PR DESCRIPTION
#### Description of change
Added missing semicolons in film_strip_block template. Without them, you cannot redefine both background and text colors.
