### PR TITLE
Fix use of non-dynamic image class in migrations

### DIFF
--- a/coderedcms/migrations/0022_auto_20210731_1853.py
+++ b/coderedcms/migrations/0022_auto_20210731_1853.py
@@ -2,6 +2,7 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
+from wagtail.images import get_image_model_string
 
 
 class Migration(migrations.Migration):
@@ -20,7 +21,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='coderedpage',
             name='og_image',
-            field=models.ForeignKey(blank=True, help_text='Shown when linking to this page on social media.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.image', verbose_name='Preview image'),
+            field=models.ForeignKey(blank=True, help_text='Shown when linking to this page on social media.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=get_image_model_string(), verbose_name='Preview image'),
         ),
         migrations.AlterField(
             model_name='coderedpage',

--- a/coderedcms/migrations/0036_filmstrip_filmpanel.py
+++ b/coderedcms/migrations/0036_filmstrip_filmpanel.py
@@ -4,6 +4,7 @@ import coderedcms.fields
 from django.db import migrations, models
 import django.db.models.deletion
 import modelcluster.fields
+from wagtail.images import get_image_model_string
 
 
 class Migration(migrations.Migration):
@@ -92,7 +93,7 @@ class Migration(migrations.Migration):
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         related_name="+",
-                        to="wagtailimages.image",
+                        to=get_image_model_string(),
                         verbose_name="Background image",
                     ),
                 ),


### PR DESCRIPTION
At some point, a few migrations slipped through referencing the concrete Image model. This of course breaks any site trying to use its own image model.