### PR TITLE
Fix for Wagtail 5.0; update test matrix to use all supported wagtail …

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,16 +31,21 @@ stages:
       vmImage: 'ubuntu-latest'
     strategy:
       matrix:
-        py3.8:
+        py3.8_wag5.0:
           PYTHON_VERSION: '3.8'
-        py3.9:
+          WAGTAIL_VERSION: '5.0.*'
+        py3.9_wag5.0:
           PYTHON_VERSION: '3.9'
-        py3.10:
+          WAGTAIL_VERSION: '5.0.*'
+        py3.10_wag5.0:
           PYTHON_VERSION: '3.10'
-        py3.11:
+          WAGTAIL_VERSION: '5.0.*'
+        py3.11_wag5.1:
           PYTHON_VERSION: '3.11'
-        py3.12:
+          WAGTAIL_VERSION: '5.1.*'
+        py3.12_wag5.2:
           PYTHON_VERSION: '3.12'
+          WAGTAIL_VERSION: '5.2.*'
 
     steps:
     - task: UsePythonVersion@0
@@ -49,7 +54,7 @@ stages:
         versionSpec: '$(PYTHON_VERSION)'
         architecture: 'x64'
 
-    - script: python -m pip install -r requirements-ci.txt
+    - script: python -m pip install -r requirements-ci.txt wagtail==$(WAGTAIL_VERSION)
       displayName: 'CR-QC: Install coderedcms from local repo'
 
     - script: coderedcms start testproject

--- a/coderedcms/wagtail_hooks.py
+++ b/coderedcms/wagtail_hooks.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.admin.menu import MenuItem
 from wagtail import hooks
 from wagtail.models import get_page_models
-from wagtail.permission_policies.pages import PagePermissionPolicy
+from wagtail.models import UserPagePermissionsProxy
 from wagtailcache.cache import clear_cache
 
 from coderedcms import __version__
@@ -95,10 +95,7 @@ def crx_forms(user, editable_forms):
         if issubclass(model, CoderedFormMixin)
     ]
     form_types = list(ContentType.objects.get_for_models(*form_models).values())
-
-    editable_forms = PagePermissionPolicy().instances_user_has_permission_for(
-        user, "change"
-    )
+    editable_forms = UserPagePermissionsProxy(user).editable_pages()
     editable_forms = editable_forms.filter(content_type__in=form_types)
 
     return editable_forms


### PR DESCRIPTION
We had made a change that was only availalbe in Wagtail 5.1, not 5.0. Fixing that by using the minimum API for all versions.

Add all supported versions of wagtail to the test matrix.