### PR TITLE
Workaround for MySQL search backend bug

### DIFF
--- a/coderedcms/templates/coderedcms/pages/search.html
+++ b/coderedcms/templates/coderedcms/pages/search.html
@@ -63,7 +63,11 @@
   {% for page in results_paginated %}
   <div class="mb-5">
     {% with page=page.specific %}
+    {% if page.search_template %}
     {% include page.search_template %}
+    {% else %}
+    {% include "coderedcms/pages/search_result.html" %}
+    {% endif %}
     {% endwith %}
   </div>
   {% endfor %}

--- a/coderedcms/views.py
+++ b/coderedcms/views.py
@@ -66,7 +66,7 @@ def search(request):
                 # Workaround for Wagtail MySQL search bug.
                 # See: https://github.com/wagtail/wagtail/issues/11273
                 backend = get_search_backend()
-                if type(backend) == MySQLSearchBackend:
+                if type(backend) is MySQLSearchBackend:
                     results = model.objects.live()
                 else:
                     results = results.type(model)


### PR DESCRIPTION
Workaround for: https://github.com/wagtail/wagtail/issues/11273

Basically, using `.type()` + `.search()` + MySQL search backend + paginate results, creates a bug in which there are no search results.

* Run a slightly different query to avoid the bug which returns no search results.
* Also add a fallback search result template for vanilla Wagtail pages which do not inherit from CoderedPage.