### PR TITLE
Fix bug caused by child having multiple terms set under the index order by classifier

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,7 @@ stages:
     - task: UsePythonVersion@0
       displayName: 'Use Python version'
       inputs:
-        versionSpec: '3.12'
+        versionSpec: '3.11'
         architecture: 'x64'
 
     - script: python -m pip install -r requirements-ci.txt

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -489,7 +489,7 @@ class CoderedPage(WagtailCacheMixin, SeoMixin, Page, metaclass=CoderedPageMeta):
                 classifier=self.index_order_by_classifier,
                 # Reverse ManyToMany of `coderedpage.classifier_terms`.
                 coderedpage=models.OuterRef("pk"),
-            )
+            )[:1]
             query = query.annotate(
                 term_sort_order=models.Subquery(terms.values("sort_order"))
             )

--- a/docs/releases/v3.0.2.rst
+++ b/docs/releases/v3.0.2.rst
@@ -5,7 +5,7 @@ v3.0.2 release notes
 Bug fixes
 ---------
 
-* Fix site search: when searching by specific page models (``search_filterable=True``) on MySQL databases, no search results would be returned. We have applied a workaround to this bug in Wagtail, with one small caveat: for example when filtering by a model ``WebPage``, the search results on SQLite and Postgres will return results for ``WebPage`` and anything inherting from ``WebPage``. On MySQL, it will ONLY return ``WebPage`` results. *However, the bug still persists in the Wagtail Admin search and will need to be fixed in a future version of Wagtail.*
+* Fix site search: when searching by specific page models (``search_filterable=True``) on MySQL databases, no search results would be returned. We have applied a workaround to this bug in Wagtail, with one small caveat: for example when filtering by a model ``WebPage``, the search results on SQLite and Postgres will return results for ``WebPage`` and anything inheriting from ``WebPage``. On MySQL, it will ONLY return ``WebPage`` results. *However, the bug still persists in the Wagtail Admin search and will need to be fixed in a future version of Wagtail.*
 
 
 Thank you!


### PR DESCRIPTION
#### Description of change
Currently, if a page has `index_order_by_classifier` set, and one or more of its live children have more than one `ClassifierTerm` under that classifier set, Django will return a programming error `more than one row returned by a subquery used as an expression`. 

This makes sense, as it is trying to sort on an order that is non deterministic. To fix, we slice the queryset to only ever contain a single term, which should also always be the highest order term due to the default ordering for the classifier terms.
