### PR TITLE
Add ability to disable registration of CRX layout and analytics settings

### DIFF
--- a/coderedcms/api/mailchimp.py
+++ b/coderedcms/api/mailchimp.py
@@ -1,5 +1,5 @@
 from wagtail.models import Site
-from coderedcms.models.wagtailsettings_models import LayoutSettings
+from coderedcms.models import get_settings_model
 
 import requests
 
@@ -13,7 +13,9 @@ class MailchimpApi:
 
     def set_access_token(self, site=None):
         site = site or Site.objects.get(is_default_site=True)
-        self.access_token = LayoutSettings.for_site(site).mailchimp_api_key
+        self.access_token = (
+            get_settings_model("layout").for_site(site).mailchimp_api_key
+        )
         if self.access_token:
             self.set_base_url()
             self.is_active = True

--- a/coderedcms/models/integration_models.py
+++ b/coderedcms/models/integration_models.py
@@ -7,8 +7,6 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel
 from wagtail import hooks
 
-from coderedcms.api.mailchimp import MailchimpApi
-
 import json
 
 
@@ -83,6 +81,8 @@ class MailchimpSubscriberIntegrationWidget(Input):
         return selectable_lists
 
     def build_list_library(self):
+        from coderedcms.api.mailchimp import MailchimpApi
+        
         mailchimp = MailchimpApi()
         list_library = {}
         if mailchimp.is_active:
@@ -126,6 +126,8 @@ class MailchimpSubscriberIntegration(models.Model):
     subscriber_json_data = models.TextField(blank=True, verbose_name=_("List"))
 
     def integration_operation(self, instance, **kwargs):
+        from coderedcms.api.mailchimp import MailchimpApi
+
         mailchimp = MailchimpApi()
         if mailchimp.is_active:
             submission_dict = kwargs["form_submission"].get_data()

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -80,7 +80,7 @@ from coderedcms.blocks import (
 from coderedcms.fields import CoderedStreamField, ColorField
 from coderedcms.forms import CoderedFormBuilder, CoderedSubmissionsListView
 from coderedcms.models.snippet_models import ClassifierTerm
-from coderedcms.models.wagtailsettings_models import LayoutSettings
+from coderedcms.models.wagtailsettings_models import get_settings_model
 from coderedcms.wagtail_flexible_forms.blocks import (
     FormFieldBlock,
     FormStepBlock,
@@ -432,7 +432,9 @@ class CoderedPage(WagtailCacheMixin, SeoMixin, Page, metaclass=CoderedPageMeta):
         if logo:
             return logo
         else:
-            layout_settings = LayoutSettings.for_site(self.get_site())
+            layout_settings = get_settings_model("layout").for_site(
+                self.get_site()
+            )
             if layout_settings.logo:
                 return layout_settings.logo
         return None
@@ -1470,9 +1472,11 @@ class CoderedFormMixin(models.Model):
                         context
                     )
                 else:
-                    genemail = LayoutSettings.for_request(
-                        request
-                    ).from_email_address
+                    genemail = (
+                        get_settings_model("layout")
+                        .for_request(request)
+                        .from_email_address
+                    )
                     if genemail:
                         message_args["from_email"] = genemail
                 # Reply-to
@@ -1536,7 +1540,9 @@ class CoderedFormMixin(models.Model):
             message_args["subject"] = self.subject
         else:
             message_args["subject"] = self.title
-        genemail = LayoutSettings.for_request(request).from_email_address
+        genemail = (
+            get_settings_model("layout").for_request(request).from_email_address
+        )
         if genemail:
             message_args["from_email"] = genemail
         if self.reply_address:
@@ -1593,10 +1599,10 @@ class CoderedFormMixin(models.Model):
             if isinstance(value, list):
                 dictionary[new_key] = ", ".join(value)
             else:
-                dictionary[
-                    new_key
-                ] = utils.attempt_protected_media_value_conversion(
-                    request, value
+                dictionary[new_key] = (
+                    utils.attempt_protected_media_value_conversion(
+                        request, value
+                    )
                 )
 
         return dictionary
@@ -2108,16 +2114,16 @@ class CoderedLocationPage(CoderedWebPage):
     def save(self, *args, **kwargs):
         if (
             self.auto_update_latlng
-            and LayoutSettings.for_site(
-                Site.objects.get(is_default_site=True)
-            ).google_maps_api_key
+            and get_settings_model("layout")
+            .for_site(Site.objects.get(is_default_site=True))
+            .google_maps_api_key
         ):
             try:
                 g = geocoder.google(
                     self.address,
-                    key=LayoutSettings.for_site(
-                        Site.objects.get(is_default_site=True)
-                    ).google_maps_api_key,
+                    key=get_settings_model("layout")
+                    .for_site(Site.objects.get(is_default_site=True))
+                    .google_maps_api_key,
                 )
                 self.latitude = g.latlng[0]
                 self.longitude = g.latlng[1]
@@ -2129,9 +2135,11 @@ class CoderedLocationPage(CoderedWebPage):
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request)
-        context["google_api_key"] = LayoutSettings.for_site(
-            Site.objects.get(is_default_site=True)
-        ).google_maps_api_key
+        context["google_api_key"] = (
+            get_settings_model("layout")
+            .for_site(Site.objects.get(is_default_site=True))
+            .google_maps_api_key
+        )
         return context
 
 
@@ -2225,7 +2233,9 @@ class CoderedLocationIndexPage(CoderedWebPage):
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request)
-        context["google_api_key"] = LayoutSettings.for_site(
-            Site.objects.get(is_default_site=True)
-        ).google_maps_api_key
+        context["google_api_key"] = (
+            get_settings_model("layout")
+            .for_site(Site.objects.get(is_default_site=True))
+            .google_maps_api_key
+        )
         return context

--- a/coderedcms/models/tests/test_navbars_and_footers.py
+++ b/coderedcms/models/tests/test_navbars_and_footers.py
@@ -4,8 +4,8 @@ from wagtail.models import Site
 
 from coderedcms.tests.testapp.models import WebPage
 from coderedcms.models.snippet_models import Footer, Navbar
-from coderedcms.models.wagtailsettings_models import (
-    LayoutSettings,
+from coderedcms.models import (
+    get_settings_model,
     NavbarOrderable,
     FooterOrderable,
 )
@@ -35,16 +35,20 @@ class NavbarFooterTestCase(WagtailPageTests):
         )
 
         # Populate settings.
-        self.settings = LayoutSettings.for_site(self.site)
+        self.settings = get_settings_model("layout").for_site(self.site)
         # layout = self.settings
         self.navbarorderable = NavbarOrderable.objects.create(
             sort_order=0,
-            navbar_chooser=LayoutSettings.objects.get(id=self.settings.id),
+            navbar_chooser=get_settings_model("layout").objects.get(
+                id=self.settings.id
+            ),
             navbar=Navbar.objects.get(id=self.navbar.id),
         )
         self.footerorderable = FooterOrderable.objects.create(
             sort_order=0,
-            footer_chooser=LayoutSettings.objects.get(id=self.settings.id),
+            footer_chooser=get_settings_model("layout").objects.get(
+                id=self.settings.id
+            ),
             footer=Footer.objects.get(id=self.footer.id),
         )
         # save settings
@@ -83,7 +87,9 @@ class NavbarFooterTestCase(WagtailPageTests):
         """
         self.navbarorderable2 = NavbarOrderable.objects.create(
             sort_order=1,
-            navbar_chooser=LayoutSettings.objects.get(id=self.settings.id),
+            navbar_chooser=get_settings_model("layout").objects.get(
+                id=self.settings.id
+            ),
             navbar=Navbar.objects.get(id=self.navbar2.id),
         )
         # get the navbar (orderable)
@@ -123,7 +129,9 @@ class NavbarFooterTestCase(WagtailPageTests):
         """
         self.footerorderable2 = FooterOrderable.objects.create(
             sort_order=1,
-            footer_chooser=LayoutSettings.objects.get(id=self.settings.id),
+            footer_chooser=get_settings_model("layout").objects.get(
+                id=self.settings.id
+            ),
             footer=Footer.objects.get(id=self.footer2.id),
         )
         # get the footer (orderable)

--- a/coderedcms/models/tests/test_wagtailsettings_models.py
+++ b/coderedcms/models/tests/test_wagtailsettings_models.py
@@ -1,9 +1,16 @@
-from django.test import Client
+from unittest.mock import patch
+
+from django.test import Client, override_settings
 from wagtail.test.utils import WagtailPageTests
 from wagtail.models import Site
 
 from coderedcms.tests.testapp.models import WebPage
-from coderedcms.models.wagtailsettings_models import AnalyticsSettings
+from coderedcms.models.wagtailsettings_models import (
+    AnalyticsSettings,
+    LayoutSettings,
+    maybe_register_setting,
+    SettingsCheckMixin,
+)
 
 
 class AnalyticsSettingsTestCase(WagtailPageTests):
@@ -55,3 +62,72 @@ class AnalyticsSettingsTestCase(WagtailPageTests):
         """
         response = self.client.get(self.homepage.url, follow=True)
         self.assertInHTML(self.settings.body_scripts, str(response.content), 1)
+
+
+class SettingsCheckTestCase(WagtailPageTests):
+
+    def setUp(self):
+        super().setUp()
+        self.site = Site.objects.get(is_default_site=True)
+        self.layout_settings = LayoutSettings.for_site(self.site)
+        self.analytics_settings = AnalyticsSettings.for_site(self.site)
+
+    def test_layoutsettings_default(self):
+        self.assertTrue(self.layout_settings.enabled())
+
+    @override_settings(CRX_ENABLE_LAYOUT_SETTINGS=True)
+    def test_layoutsettings_enabled(self):
+
+        self.assertTrue(self.layout_settings.enabled())
+
+    @override_settings(CRX_ENABLE_LAYOUT_SETTINGS=False)
+    def test_layoutsettings_disabled(self):
+
+        self.assertFalse(self.layout_settings.enabled())
+
+    def test_analyticssettings_default(self):
+
+        self.assertTrue(self.analytics_settings.enabled())
+
+    @override_settings(CRX_ENABLE_ANALYTICS_SETTINGS=True)
+    def test_analyticssettings_enabled(self):
+
+        self.assertTrue(self.analytics_settings.enabled())
+
+    @override_settings(CRX_ENABLE_ANALYTICS_SETTINGS=False)
+    def test_analyticssettings_disabled(self):
+
+        self.assertFalse(self.analytics_settings.enabled())
+
+
+class DummySettingsObject(SettingsCheckMixin):
+    ENABLE_SETTINGS = "CRX_ENABLE_LAYOUT_SETTINGS"
+
+
+class MaybeRegisterSettingTestCase(WagtailPageTests):
+    """Testing the maybe_register_setting decorator.
+
+    These tests use a dummy settings object to test the two paths
+    through the decorator which determine whether or not register_settings
+    is called."""
+
+    def setUp(self):
+        super().setUp()
+        self.dummy_settings = DummySettingsObject()
+
+    @patch("coderedcms.models.wagtailsettings_models.register_setting")
+    def test_decorator_enabled(self, mock_register_setting):
+        """Test that the decorator calls register_setting
+        with no override setting (default)."""
+        maybe_register_setting(icon="foobar")(self.dummy_settings)
+        mock_register_setting.assert_called_once_with(
+            self.dummy_settings, icon="foobar"
+        )
+
+    @override_settings(CRX_ENABLE_LAYOUT_SETTINGS=False)
+    @patch("coderedcms.models.wagtailsettings_models.register_setting")
+    def test_decorator_disabled(self, mock_register_setting):
+        """Test that the decorator does not call register_setting
+        when override setting is False."""
+        maybe_register_setting(icon="foobar")(self.dummy_settings)
+        mock_register_setting.assert_not_called()

--- a/coderedcms/models/wagtailsettings_models.py
+++ b/coderedcms/models/wagtailsettings_models.py
@@ -367,3 +367,39 @@ class AnalyticsSettings(SettingsCheckMixin, AbstractAnalyticsSettings):
     ENABLE_SETTINGS = "CRX_ENABLE_ANALYTICS_SETTINGS"
 
 
+def get_settings_model_string(model):
+    """
+    Get the dotted ``app.Model`` name for the model as a string.
+    """
+    if model == "layout":
+        return getattr(
+            settings, "CRX_LAYOUT_SETTINGS_MODEL", "coderedcms.LayoutSettings"
+        )
+    elif model == "analytics":
+        return getattr(
+            settings,
+            "CRX_ANALYTICS_SETTINGS_MODEL",
+            "coderedcms.AnalyticsSettings",
+        )
+
+
+def get_settings_model(model):
+    """
+    Get the model from the setting or default.
+
+    Defaults to the standard :class:`~coderedcms.LayoutSettings` model
+    if no custom model is defined.
+    """
+    from django.apps import apps
+
+    model_string = get_settings_model_string(model)
+    try:
+        return apps.get_model(model_string, require_ready=False)
+    except ValueError:
+        raise ImproperlyConfigured(
+            f"The setting for {model} must be of the form 'app_label.model_name'"
+        )
+    except LookupError:
+        raise ImproperlyConfigured(
+            f"The setting for {model} refers to model '{model_string}' that has not been installed"
+        )

--- a/coderedcms/templatetags/coderedcms_tags.py
+++ b/coderedcms/templatetags/coderedcms_tags.py
@@ -15,7 +15,7 @@ from coderedcms.forms import SearchForm
 from coderedcms.models.snippet_models import Navbar, Footer
 from coderedcms.settings import crx_settings as crx_settings_obj
 from coderedcms.settings import get_bootstrap_setting
-from coderedcms.models.wagtailsettings_models import LayoutSettings
+from coderedcms.models import get_settings_model
 
 register = template.Library()
 
@@ -70,7 +70,7 @@ def get_pictures(collection_id):
 
 @register.simple_tag(takes_context=True)
 def get_navbar_css(context):
-    layout = LayoutSettings.for_request(context["request"])
+    layout = get_settings_model("layout").for_request(context["request"])
     fixed = "fixed-top" if layout.navbar_fixed else ""
     return " ".join(
         [
@@ -85,7 +85,7 @@ def get_navbar_css(context):
 
 @register.simple_tag(takes_context=True)
 def get_navbars(context) -> "QuerySet[Navbar]":
-    layout = LayoutSettings.for_request(context["request"])
+    layout = get_settings_model("layout").for_request(context["request"])
     navbarorderables = layout.site_navbar.all()
     navbars = Navbar.objects.filter(
         navbarorderable__in=navbarorderables
@@ -95,7 +95,7 @@ def get_navbars(context) -> "QuerySet[Navbar]":
 
 @register.simple_tag(takes_context=True)
 def get_footers(context) -> "QuerySet[Footer]":
-    layout = LayoutSettings.for_request(context["request"])
+    layout = get_settings_model("layout").for_request(context["request"])
     footerorderables = layout.site_footer.all()
     footers = Footer.objects.filter(
         footerorderable__in=footerorderables

--- a/coderedcms/tests/test_urls.py
+++ b/coderedcms/tests/test_urls.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from wagtail.models import Site, Page
 from wagtail.images.tests.utils import Image, get_test_image_file
 
-from coderedcms.models import LayoutSettings
+from coderedcms.models import get_settings_model
 from coderedcms.tests.testapp.models import (
     EventPage,
     EventIndexPage,
@@ -333,7 +333,7 @@ class TestFavicon(unittest.TestCase):
         # Get the default site
         site = Site.objects.filter(is_default_site=True)[0]
         # Ensure the favicon is blank
-        layout = LayoutSettings.for_site(site)
+        layout = get_settings_model("layout").for_site(site)
         layout.favicon = None
         layout.save()
         # Expect a 404
@@ -345,7 +345,7 @@ class TestFavicon(unittest.TestCase):
         # Get the default site
         site = Site.objects.filter(is_default_site=True)[0]
         # Set a dummy favicon
-        layout = LayoutSettings.for_site(site)
+        layout = get_settings_model("layout").for_site(site)
         img = Image.objects.create(
             title="Test image",
             file=get_test_image_file(),

--- a/coderedcms/views.py
+++ b/coderedcms/views.py
@@ -26,7 +26,7 @@ from wagtail.search.backends import get_search_backend
 from wagtail.search.backends.database.mysql.mysql import MySQLSearchBackend
 from coderedcms import utils
 from coderedcms.forms import SearchForm
-from coderedcms.models import CoderedPage, LayoutSettings
+from coderedcms.models import CoderedPage, get_settings_model
 from coderedcms.importexport import (
     convert_csv_to_json,
     import_pages,
@@ -78,7 +78,10 @@ def search(request):
         if results:
             results = results.search(search_query)
             paginator = Paginator(
-                results, LayoutSettings.for_request(request).search_num_results
+                results,
+                get_settings_model("layout")
+                .for_request(request)
+                .search_num_results,
             )
             page = request.GET.get("p", 1)
             try:
@@ -126,7 +129,7 @@ def serve_protected_file(request, path):
 
 
 def favicon(request):
-    icon = LayoutSettings.for_request(request).favicon
+    icon = get_settings_model("layout").for_request(request).favicon
     if icon:
         # Try to convert to webp, otherwise pass original file format
         # This will happen mainly if the file is an SVG

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -16,3 +16,4 @@ website with Wagtail CRX.
     docker
     use_custom_image_model
     convert_image_model
+    use_custom_settings_model

--- a/docs/how_to/use_custom_settings_model.rst
+++ b/docs/how_to/use_custom_settings_model.rst
@@ -1,0 +1,153 @@
+Using a Custom Settings Model
+============================================
+
+Wagtail CRX provides two settings models, `LayoutSettings` and
+`AnalyticsSettings`, which enable admins to manage site-specific settings. If
+you need to store additional site-specific settings and do not wish to have
+multiple "Settings" menus, you can disable the default models and create a
+custom settings model. 
+
+There are abstract classes for each of the default settings models that you can
+subclass or you can start from scratch, using the Wagtail CRX settings models as
+a guide. The abstract classes are ``coderedcms.models.AbstractLayoutSettings``
+and ``coderedcms.models.AbstractAnalyticsSettings``.
+
+
+.. versionadded:: 3.0.4
+
+    Added support for custom settings models. You must be on Wagtail CRX version
+    3.0.4 or higher in order to follow this guide.
+
+
+Step 1: Disable the default settings model(s)
+---------------------------------------------
+
+Disable one or both of the default settings models by adding the following to
+your settings file::
+
+    CRX_ENABLE_LAYOUT_SETTINGS = False
+    CRX_ENABLE_ANALYTICS_SETTINGS = False
+
+Setting these to ``False`` will prevent the default settings model from being
+registered with Wagtail Admin.
+
+Step 2: Create a custom settings model
+--------------------------------------
+
+Create a custom settings model by subclassing the appropriate base class and
+adding your own fields. Register the model with the `@register_setting`
+decorator, choosing an icon to represent the model in the admin.
+
+For example
+
+.. code-block:: python
+
+    from wagtail.contrib.settings.models import register_setting    
+    from coderedcms.models import AbstractLayoutSettings
+
+    @register_setting(icon="cr-desktop")
+    class CustomLayoutSettings(AbstractLayoutSettings):
+        custom_field = models.CharField(max_length=255, blank=True, null=True)
+
+        class Meta:
+            verbose_name = "Custom Layout Settings"
+            verbose_name_plural = "Custom Layout Settings"
+
+.. note::
+
+    The default models are always created so you must choose a different name
+    for your custom model. More on this in `Step 4: Override the default
+    templates` below.
+
+Step 3: Create custom navbar and footer
+---------------------------------------
+
+If you subclass ``coderedcms.models.AbstractLayoutSettings``, you should define
+your own navbar and footer models so that they can be selected in your custom
+settings. If you do not subclass the default abstract class or do not add a
+navbar or footer attribute to your custom settings, you can skip this step.
+
+.. code-block:: python
+
+    class CustomNavbarOrderable(Orderable, models.Model):
+        navbar_chooser = ParentalKey(
+            CustomLayoutSettings,
+            related_name="site_navbar",
+            verbose_name=_("Site Navbars"),
+        )
+        navbar = models.ForeignKey(
+            Navbar,
+            blank=True,
+            null=True,
+            on_delete=models.CASCADE,
+        )
+
+        panels = [FieldPanel("navbar")]
+
+    class CustomFooterOrderable(Orderable, models.Model):
+        footer_chooser = ParentalKey(
+            CustomLayoutSettings,
+            related_name="site_footer",
+            verbose_name=_("Site Footers"),
+        )
+        footer = models.ForeignKey(
+            Footer,
+            blank=True,
+            null=True,
+            on_delete=models.CASCADE,
+        )
+
+        panels = [FieldPanel("footer")]
+
+Step 4: Override the default templates
+--------------------------------------
+
+Wagtail CRX templates reference the default models. You must override the
+following templates to reference your custom model:
+
+* coderedcms/templates/wagtailadmin/base.html
+* coderedcms/templates/coderedcms/pages/base.html
+* coderedcms/templates/coderedcms/snippets/footer.html
+* coderedcms/templates/coderedcms/snippets/navbar.html
+* coderedcms/templates/coderedcms/blocks/google_map.html
+* coderedcms/templates/coderedcms/pages/search.html
+
+For example, copy ``coderedcms/templates/coderedcms/snippets/footer.html`` from
+Wagtail CRX to ``templates/coderedcms/snippets/footer.html`` in your project and
+change the second line so that:
+
+.. code-block:: Django
+    :emphasize-lines: 2
+
+    {% load wagtailcore_tags coderedcms_tags %}
+    {% if settings.coderedcms.LayoutSettings.site_footer %}
+    <footer>
+      {% get_footers as footers %}
+      {% for footer in footers %}
+      <div {% if footer.custom_id %}id="{{footer.custom_id}}"{% endif %} {% if footer.custom_css_class %}class="{{footer.custom_css_class}}"{% endif %}>
+          {% for item in footer.content %}
+          {% include_block item with settings=settings %}
+          {% endfor %}
+      </div>
+      {% endfor %}
+    </footer>
+    {% endif %}
+
+becomes:
+
+.. code-block:: Django
+    :emphasize-lines: 2
+
+    {% load wagtailcore_tags coderedcms_tags %}
+    {% if settings.coderedcms.CustomLayoutSettings.site_footer %}
+    <footer>
+      {% get_footers as footers %}
+      {% for footer in footers %}
+      <div {% if footer.custom_id %}id="{{footer.custom_id}}"{% endif %} {% if footer.custom_css_class %}class="{{footer.custom_css_class}}"{% endif %}>
+          {% for item in footer.content %}
+          {% include_block item with settings=settings %}
+          {% endfor %}
+      </div>
+      {% endfor %}
+    </footer>
+    {% endif %}


### PR DESCRIPTION
Allow developers who need to store additional site-specific settings and do not wish to have multiple "Settings" menus to disable the default models and create custom settings models. 