### PR TITLE
Include the absolute URL to the sitemap in the robots.txt file

### DIFF
--- a/coderedcms/templates/robots.txt
+++ b/coderedcms/templates/robots.txt
@@ -1,3 +1,5 @@
+{% load wagtailcore_tags %}
+{% wagtail_site as site %}
 User-agent: *
 Disallow: /admin/
 
@@ -7,4 +9,4 @@ Disallow: /django-admin/
 User-agent: *
 Allow: /
 
-Sitemap: /sitemap.xml
+Sitemap: {{ site.root_url }}/sitemap.xml


### PR DESCRIPTION
#### Description of change
In the robots.txt file, the value of the sitemap field is a relative URL.
This should be changed to an absolute URL.
See protocol: https://sitemaps.org/protocol.html#submit_robots

For example, in the Google search console, this error message appears when it's a relative url:

> "Invalid sitemap URL" incomprehensible syntax

I think it would be interesting to have a default sitemap field in the right format using `root_url`.

What do you think of this change?
