### PR TITLE
Fix Overflow on Carousel

### DIFF
--- a/coderedcms/static/coderedcms/scss/_crx-bs-overrides.scss
+++ b/coderedcms/static/coderedcms/scss/_crx-bs-overrides.scss
@@ -15,7 +15,7 @@
 
 // Carousel
 .container-fluid .carousel {
-  margin: 0 -15px;
+  margin: 0 -12px;
 }
 
 .carousel .no-image {


### PR DESCRIPTION
Massive juicer of a pull request... Fixes horizontal scrollbar/overflow from appearing when carousel is in a fluid (full width) container. Applies to carousel in **Responsive Grid Row** and **Hero Unit**. Tested in FF and Chromium.

![Screenshot from 2024-06-13 15-57-11](https://github.com/coderedcorp/coderedcms/assets/13271324/2c975e9e-23b1-4b73-8107-3f7abdf9367d)