### PR TITLE
Fix default field type in forms

### DIFF
--- a/coderedcms/forms.py
+++ b/coderedcms/forms.py
@@ -186,7 +186,7 @@ class CoderedFormField(AbstractFormField):
         max_length=16,
         choices=FORM_FIELD_CHOICES,
         blank=False,
-        default="Single line text",
+        default="singleline",
     )
 
 


### PR DESCRIPTION
Fixes #628. Minor fix providing a valid default for the form field type.
