### PR TITLE
Fix site name on login screen

### DIFF
--- a/coderedcms/templates/wagtailadmin/login.html
+++ b/coderedcms/templates/wagtailadmin/login.html
@@ -1,4 +1,6 @@
 {% extends "wagtailadmin/login.html" %}
 {% load coderedcms_tags i18n %}
+{% block branding_login %}
 {% django_setting "WAGTAIL_SITE_NAME" as wagtail_site_name %}
-{% block branding_login %}{% trans 'Sign in to' %} {{ wagtail_site_name }}{% endblock %}
+{% trans 'Sign in to' %} {{ wagtail_site_name }}
+{% endblock %}


### PR DESCRIPTION
Fixes #646 . Problem was due to variable scoping in django templates.