### PR TITLE
Provide time_zone in event index page context

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1216,7 +1216,7 @@ class CoderedEventIndexPage(CoderedWebPage):
 
     def get_context(self, request, *args, **kwargs):
         ctx = super().get_context(request, *args, **kwargs)
-        ctx["time_zone"] = settings.get("TIME_ZONE", "")
+        ctx["time_zone"] = settings.TIME_ZONE
         return ctx
 
     def get_calendar_events(

--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -1214,6 +1214,11 @@ class CoderedEventIndexPage(CoderedWebPage):
 
         return super().get_index_children()
 
+    def get_context(self, request, *args, **kwargs):
+        ctx = super().get_context(request, *args, **kwargs)
+        ctx["time_zone"] = settings.get("TIME_ZONE", "")
+        return ctx
+
     def get_calendar_events(
         self, start: Union[datetime, date], end: Union[datetime, date]
     ) -> List[Dict[str, str]]:


### PR DESCRIPTION
Adds `time_zone` to the `EventIndexPage` context, since the template uses that variable.