### PR TITLE
Fix Card Footer

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/card_foot.html
+++ b/coderedcms/templates/coderedcms/blocks/card_foot.html
@@ -9,9 +9,9 @@
     {% if self.subtitle %}<h6 class="card-subtitle mb-2 text-muted">{{self.subtitle}}</h6>{% endif %}
     <div class="card-text">{{self.description}}</div>
   </div>
-  <div class="card-footer">
-    {% for button in self.links %}
-    {% include_block button %}
-    {% endfor %}
-  </div>
+  {% for button in self.links %}
+    <div class="card-footer">
+      {% include_block button %}
+    </div>
+  {% endfor %}
 </div>


### PR DESCRIPTION
Improved the default card template to hide the card-footer div if a link is not added. Current shows an empty section which shouldn't be visible if there is no link:

![image](https://github.com/user-attachments/assets/8b90bd45-b051-406b-9936-1198834b5a6d)

Improved version hides the card footer if no link has been specified in the Wagtail editor:

![image](https://github.com/user-attachments/assets/f6023f44-7c08-45bb-bb02-7e2f85c0efd5)