### PR TITLE
Story 671: Remove legacy document hook

### DIFF
--- a/coderedcms/models/integration_models.py
+++ b/coderedcms/models/integration_models.py
@@ -95,14 +95,14 @@ class MailchimpSubscriberIntegrationWidget(Input):
                 }
 
                 list_library[mlist["id"]]["merge_fields"] = (
-                    mailchimp.get_merge_fields_for_list(
-                        mlist["id"]
-                    )["merge_fields"]
+                    mailchimp.get_merge_fields_for_list(mlist["id"])[
+                        "merge_fields"
+                    ]
                 )
                 list_library[mlist["id"]]["interest_categories"] = (
-                    mailchimp.get_interest_categories_for_list(
-                        mlist["id"]
-                    )["categories"]
+                    mailchimp.get_interest_categories_for_list(mlist["id"])[
+                        "categories"
+                    ]
                 )
 
                 for category in list_library[mlist["id"]][

--- a/coderedcms/wagtail_hooks.py
+++ b/coderedcms/wagtail_hooks.py
@@ -1,4 +1,3 @@
-
 from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
 from django.urls import reverse

--- a/coderedcms/wagtail_hooks.py
+++ b/coderedcms/wagtail_hooks.py
@@ -1,7 +1,5 @@
-import mimetypes
 
 from django.contrib.contenttypes.models import ContentType
-from django.http.response import HttpResponse
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html

--- a/coderedcms/wagtail_hooks.py
+++ b/coderedcms/wagtail_hooks.py
@@ -105,21 +105,6 @@ def crx_forms(user, editable_forms):
     return editable_forms
 
 
-@hooks.register("before_serve_document")
-def serve_document_directly(document, request):
-    """
-    This hook prevents documents from being downloaded unless
-    specified by an <a> tag with the download attribute.
-    """
-    content_type, content_encoding = mimetypes.guess_type(document.filename)
-    response = HttpResponse(document.file.read(), content_type=content_type)
-    response["Content-Disposition"] = 'inline;filename="{0}"'.format(
-        document.filename
-    )
-    response["Content-Encoding"] = content_encoding
-    return response
-
-
 class ImportExportMenuItem(MenuItem):
     def is_shown(self, request):
         return request.user.is_superuser


### PR DESCRIPTION
#### Description of change

Remove a legacy wagtail_hook that was fixing an issue that no longer exists and was now causing problems.

This wagtail hook was preventing the download of documents, even when they should be

closes #671 
