### PR TITLE
Fix pytz import issue

### DIFF
--- a/coderedcms/models/page_models.py
+++ b/coderedcms/models/page_models.py
@@ -8,6 +8,7 @@ import os
 import warnings
 from datetime import date
 from datetime import datetime
+from datetime import timezone as dttimezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Dict
@@ -17,9 +18,6 @@ from typing import Tuple
 from typing import Union
 
 import geocoder
-
-# This is a requirement for icalendar, even if django doesn't require it
-import pytz
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -1027,13 +1025,15 @@ class CoderedEventPage(CoderedWebPage, BaseEvent):
             ical_event.add("location", self.address)
 
         if dt_start:
-            # Convert to utc to remove timezone confusion
-            dt_start = dt_start.astimezone(pytz.utc)
+            # Convert to UTC to remove timezone confusion in ical
+            # clients (i.e. Outlook).
+            dt_start = dt_start.astimezone(dttimezone.utc)
             ical_event.add("dtstart", dt_start)
 
             if dt_end:
-                # Convert to utc to remove timezone confusion
-                dt_end = dt_end.astimezone(pytz.utc)
+                # Convert to UTC to remove timezone confusion in ical
+                # clients (i.e. Outlook).
+                dt_end = dt_end.astimezone(dttimezone.utc)
                 ical_event.add("dtend", dt_end)
 
             # Add a reminder alarm

--- a/coderedcms/views.py
+++ b/coderedcms/views.py
@@ -186,7 +186,9 @@ def event_generate_single_ical_for_event(request):
 
     # Generate the ical file.
     ical = Calendar()
+    # Our product name that is generating this file.
     ical.add("prodid", "-//Wagtail CRX//")
+    # Version of the ical standard.
     ical.add("version", "2.0")
     ical.add_component(
         event.create_single_ical(dt_start=dt_start, dt_end=dt_end)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "django-bootstrap5==24.3",
     "Django>=4.2,<6.0",  # should be the same as wagtail
     "geocoder==1.38.*",
-    "icalendar==6.0.*",
+    "icalendar==6.1.*",
     "wagtail>=6.3,<7.0",
     "wagtail-cache>=2.4,<3",
     "wagtail-flexible-forms==2.*",


### PR DESCRIPTION
Fixes #678 

I didn't do a complete thorough test of Wagtail 6.4 compatibility, but confirmed this particular issue is solved and most general functionality works on Wagtail 6.4.

This should get backported to 4.1 at minimum.