### PR TITLE
Update all custom image tags to use the wagtail 'alt' attribute

### DIFF
--- a/coderedcms/templates/coderedcms/blocks/base_link_block.html
+++ b/coderedcms/templates/coderedcms/blocks/base_link_block.html
@@ -11,7 +11,7 @@
     {% if ga_event_category %}data-ga-event-category="{{ ga_event_category }}"{% endif %}>
     {% if value.image %}
     {% image value.image max-256x256 format-webp preserve-svg as img %}
-    <img src="{{img.url}}" class="w-100" alt="{{img.image.title}}">
+    <img src="{{img.url}}" class="w-100" alt="{{img.image.alt}}">
     {% elif value.display_text %}
     {{value.display_text|safe}}
     {% elif value.page %}

--- a/coderedcms/templates/coderedcms/blocks/card_block.html
+++ b/coderedcms/templates/coderedcms/blocks/card_block.html
@@ -2,7 +2,7 @@
 <div class="card mb-3 {{self.settings.custom_css_class}}" {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
   {% if self.image %}
   {% image self.image fill-800x450 format-webp preserve-svg as card_img %}
-  <img class="card-img-top w-100" src="{{card_img.url}}" alt="{{card_img.title}}">
+  <img class="card-img-top w-100" src="{{card_img.url}}" alt="{{card_img.alt}}">
   {% endif %}
   <div class="card-body">
     {% if self.title %}<h5 class="card-title">{{self.title}}</h5>{% endif %}

--- a/coderedcms/templates/coderedcms/blocks/card_blurb.html
+++ b/coderedcms/templates/coderedcms/blocks/card_blurb.html
@@ -2,7 +2,7 @@
 <div class="card mb-3 border-0 bg-transparent text-center {{self.settings.custom_css_class}}" {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
   {% if self.image %}
   {% image self.image fill-256x256 format-webp preserve-svg as card_img %}
-  <img class="rounded-circle w-25 mx-auto" src="{{card_img.url}}" alt="{{card_img.title}}">
+  <img class="rounded-circle w-25 mx-auto" src="{{card_img.url}}" alt="{{card_img.alt}}">
   {% endif %}
   <div class="card-body">
     {% if self.title %}<h5 class="card-title">{{self.title}}</h5>{% endif %}

--- a/coderedcms/templates/coderedcms/blocks/card_foot.html
+++ b/coderedcms/templates/coderedcms/blocks/card_foot.html
@@ -2,7 +2,7 @@
 <div class="card mb-3 {{self.settings.custom_css_class}}" {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %}>
   {% if self.image %}
   {% image self.image fill-800x450 format-webp preserve-svg as card_img %}
-  <img class="card-img-top w-100" src="{{card_img.url}}" alt="{{card_img.title}}">
+  <img class="card-img-top w-100" src="{{card_img.url}}" alt="{{card_img.alt}}">
   {% endif %}
   <div class="card-body">
     {% if self.title %}<h5 class="card-title">{{self.title}}</h5>{% endif %}

--- a/coderedcms/templates/coderedcms/blocks/card_head.html
+++ b/coderedcms/templates/coderedcms/blocks/card_head.html
@@ -3,7 +3,7 @@
   {% if self.title %}<h5 class="card-header">{{self.title}}</h5>{% endif %}
   {% if self.image %}
   {% image self.image fill-800x450 format-webp preserve-svg as card_img %}
-  <img class="w-100" src="{{card_img.url}}" alt="{{card_img.title}}">
+  <img class="w-100" src="{{card_img.url}}" alt="{{card_img.alt}}">
   {% endif %}
   <div class="card-body">
     {% if self.subtitle %}<h6 class="card-subtitle mb-2 text-muted">{{self.subtitle}}</h6>{% endif %}

--- a/coderedcms/templates/coderedcms/blocks/card_head_foot.html
+++ b/coderedcms/templates/coderedcms/blocks/card_head_foot.html
@@ -3,7 +3,7 @@
   {% if self.title %}<h5 class="card-header">{{self.title}}</h5>{% endif %}
   {% if self.image %}
   {% image self.image fill-800x450 format-webp preserve-svg as card_img %}
-  <img class="w-100" src="{{card_img.url}}" alt="{{card_img.title}}">
+  <img class="w-100" src="{{card_img.url}}" alt="{{card_img.alt}}">
   {% endif %}
   <div class="card-body">
     {% if self.subtitle %}<h6 class="card-subtitle mb-2 text-muted">{{self.subtitle}}</h6>{% endif %}

--- a/coderedcms/templates/coderedcms/blocks/carousel_block.html
+++ b/coderedcms/templates/coderedcms/blocks/carousel_block.html
@@ -19,7 +19,7 @@
       {% block carousel_slide_image %}
       {% if item.image %}
       {% image item.image fill-1600x900 format-webp preserve-svg as carouselimage %}
-      <img class="d-block w-100" src="{{carouselimage.url}}" alt="{{carouselimage.image.title}}">
+      <img class="d-block w-100" src="{{carouselimage.url}}" alt="{{carouselimage.image.alt}}">
       {% endif %}
       {% endblock %}
       <div class="carousel-caption d-none d-md-block">

--- a/coderedcms/templates/coderedcms/blocks/image_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_block.html
@@ -1,3 +1,3 @@
 {% load wagtailimages_tags %}
 {% image self.image max-1600x1600 format-webp preserve-svg as self_image %}
-<img src="{{self_image.url}}" class="img-fluid {{self.settings.custom_css_class}}" {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %} alt="{{self_image.image.title}}">
+<img src="{{self_image.url}}" class="img-fluid {{self.settings.custom_css_class}}" {% if self.settings.custom_id %}id="{{self.settings.custom_id}}"{% endif %} alt="{{self_image.image.alt}}">

--- a/coderedcms/templates/coderedcms/blocks/image_gallery_block.html
+++ b/coderedcms/templates/coderedcms/blocks/image_gallery_block.html
@@ -9,7 +9,7 @@
     <div class="col-sm-6 col-md-4 col-lg-3 my-3">
       <a href="#" class="lightbox-preview" data-bs-toggle="modal" data-bs-target="#modal-{{modal_id}}">
         <img class="img-thumbnail w-100" src="{{picture_image.url}}" data-original-src="{{original_image.url}}"
-          alt="{{picture_image.image.title}}" title="{{picture_image.image.title}}">
+          alt="{{picture_image.image.alt}}" title="{{picture_image.image.title}}">
       </a>
     </div>
     {% endfor %}

--- a/coderedcms/templates/coderedcms/pages/article_page.mini.html
+++ b/coderedcms/templates/coderedcms/pages/article_page.mini.html
@@ -3,7 +3,7 @@
   {% if page.cover_image %}
   {% image page.cover_image fill-800x450 format-webp preserve-svg as card_img %}
   <a href="{% pageurl page %}" title="{{ page.title }}">
-    <img class="card-img-top w-100" src="{{ card_img.url }}" alt="{{ card_img.title }}">
+    <img class="card-img-top w-100" src="{{ card_img.url }}" alt="{{ card_img.alt }}">
   </a>
   {% endif %}
   <div class="card-body">

--- a/coderedcms/templates/coderedcms/pages/article_page.search.html
+++ b/coderedcms/templates/coderedcms/pages/article_page.search.html
@@ -4,7 +4,7 @@
   {% image page.cover_image fill-800x450 format-webp preserve-svg as cover_image %}
   <div class="col-4 col-md-3 col-lg-2">
     <a href="{{page.url}}" title="{{page.title}}">
-      <img src="{{cover_image.url}}" class="w-100" alt="{{page.title}}">
+      <img src="{{cover_image.url}}" class="w-100" alt="{{page.alt}}">
     </a>
   </div>
   {% endif %}

--- a/coderedcms/templates/coderedcms/pages/event_page.mini.html
+++ b/coderedcms/templates/coderedcms/pages/event_page.mini.html
@@ -3,7 +3,7 @@
   {% if page.cover_image %}
   {% image page.cover_image fill-800x450 format-webp preserve-svg as card_img %}
   <a href="{% pageurl page %}" title="{{ page.title }}">
-    <img class="card-img-top w-100" src="{{ card_img.url }}" alt="{{ card_img.title }}">
+    <img class="card-img-top w-100" src="{{ card_img.url }}" alt="{{ card_img.alt }}">
   </a>
   {% endif %}
   <div class="card-body">

--- a/coderedcms/templates/coderedcms/pages/event_page.search.html
+++ b/coderedcms/templates/coderedcms/pages/event_page.search.html
@@ -4,7 +4,7 @@
   {% image page.cover_image fill-800x450 format-webp preserve-svg as cover_image %}
   <div class="col-4 col-md-3 col-lg-2">
     <a href="{{ page.url }}" title="{{ page.title }}">
-      <img src="{{ cover_image.url }}" class="w-100" alt="{{ page.title }}">
+      <img src="{{ cover_image.url }}" class="w-100" alt="{{ page.alt }}">
     </a>
   </div>
   {% endif %}

--- a/coderedcms/templates/coderedcms/pages/page.mini.html
+++ b/coderedcms/templates/coderedcms/pages/page.mini.html
@@ -3,7 +3,7 @@
   {% if page.cover_image %}
   {% image page.cover_image fill-800x450 format-webp preserve-svg as card_img %}
   <a href="{% pageurl page %}" title="{{ page.title }}">
-    <img class="card-img-top w-100" src="{{ card_img.url }}" alt="{{ card_img.title }}">
+    <img class="card-img-top w-100" src="{{ card_img.url }}" alt="{{ card_img.alt }}">
   </a>
   {% endif %}
   <div class="card-body">


### PR DESCRIPTION
#### Description of change
Currently, all blocks and pages of Wagtail CRX use the title of the image as alt text. This is a legacy feature before Wagtail supported setting alt text on the image itself. Since this feature has been added to wagtail, CRX should also support this feature.

